### PR TITLE
simplify precedences + various parentheses bug fixes in stream

### DIFF
--- a/src/impala/ast.h
+++ b/src/impala/ast.h
@@ -1247,7 +1247,7 @@ private:
 class PrefixExpr : public Expr {
 public:
     enum Tag {
-#define IMPALA_PREFIX(tok, str, prec) tok = Token:: tok,
+#define IMPALA_PREFIX(tok, str) tok = Token:: tok,
 #include "impala/tokenlist.h"
         MUT
     };
@@ -1287,8 +1287,8 @@ private:
 class InfixExpr : public Expr {
 public:
     enum Tag {
-#define IMPALA_INFIX_ASGN(tok, str, lprec, rprec) tok = Token:: tok,
-#define IMPALA_INFIX(     tok, str, lprec, rprec) tok = Token:: tok,
+#define IMPALA_INFIX_ASGN(tok, str)       tok = Token:: tok,
+#define IMPALA_INFIX(     tok, str, prec) tok = Token:: tok,
 #include "impala/tokenlist.h"
     };
 

--- a/src/impala/impala.cpp
+++ b/src/impala/impala.cpp
@@ -25,16 +25,12 @@ int global_num_errors = 0;
 int num_warnings() { return global_num_warnings; }
 int num_errors() { return global_num_errors; }
 
-Type2Prec PrecTable::prefix_r;
 Type2Prec PrecTable::infix_l;
 Type2Prec PrecTable::infix_r;
-Type2Prec PrecTable::postfix_l;
 
 void PrecTable::init() {
-#define IMPALA_PREFIX(    tok, t_str,    r)  PrecTable::prefix_r[Token:: tok] = r;
-#define IMPALA_POSTFIX(   tok, t_str, l   ) PrecTable::postfix_l[Token:: tok] = l;
-#define IMPALA_INFIX(     tok, t_str, l, r)   PrecTable::infix_l[Token:: tok] = l; PrecTable::infix_r[Token:: tok] = r;
-#define IMPALA_INFIX_ASGN(tok, t_str, l, r)   PrecTable::infix_l[Token:: tok] = l; PrecTable::infix_r[Token:: tok] = r;
+#define IMPALA_INFIX(     tok, t_str, prec) PrecTable::infix_l[Token::tok] = prec; PrecTable::infix_r[Token:: tok] = Prec(prec+1);
+#define IMPALA_INFIX_ASGN(tok, t_str)       PrecTable::infix_l[Token::tok] = Prec(Assign+1); PrecTable::infix_r[Token:: tok] = Assign;
 #include "impala/tokenlist.h"
 }
 

--- a/src/impala/impala.cpp
+++ b/src/impala/impala.cpp
@@ -25,7 +25,7 @@ int global_num_errors = 0;
 int num_warnings() { return global_num_warnings; }
 int num_errors() { return global_num_errors; }
 
-Prec PrecTable::infix[Token::Num_Tokens];
+Prec PrecTable::infix[Token::Num];
 
 void PrecTable::init() {
 #define IMPALA_INFIX(     tok, t_str, prec) PrecTable::infix[Token::tok] = Prec::prec;

--- a/src/impala/impala.cpp
+++ b/src/impala/impala.cpp
@@ -28,8 +28,8 @@ int num_errors() { return global_num_errors; }
 Prec PrecTable::infix[Token::Num_Tokens];
 
 void PrecTable::init() {
-#define IMPALA_INFIX(     tok, t_str, prec) PrecTable::infix[Token::tok] = prec;
-#define IMPALA_INFIX_ASGN(tok, t_str)       PrecTable::infix[Token::tok] = Assign;
+#define IMPALA_INFIX(     tok, t_str, prec) PrecTable::infix[Token::tok] = Prec::prec;
+#define IMPALA_INFIX_ASGN(tok, t_str)       PrecTable::infix[Token::tok] = Prec::Assign;
 #include "impala/tokenlist.h"
 }
 

--- a/src/impala/impala.cpp
+++ b/src/impala/impala.cpp
@@ -25,12 +25,11 @@ int global_num_errors = 0;
 int num_warnings() { return global_num_warnings; }
 int num_errors() { return global_num_errors; }
 
-Type2Prec PrecTable::infix_l;
-Type2Prec PrecTable::infix_r;
+Prec PrecTable::infix[Token::Num_Tokens];
 
 void PrecTable::init() {
-#define IMPALA_INFIX(     tok, t_str, prec) PrecTable::infix_l[Token::tok] = prec; PrecTable::infix_r[Token:: tok] = Prec(prec+1);
-#define IMPALA_INFIX_ASGN(tok, t_str)       PrecTable::infix_l[Token::tok] = Prec(Assign+1); PrecTable::infix_r[Token:: tok] = Assign;
+#define IMPALA_INFIX(     tok, t_str, prec) PrecTable::infix[Token::tok] = prec;
+#define IMPALA_INFIX_ASGN(tok, t_str)       PrecTable::infix[Token::tok] = Assign;
 #include "impala/tokenlist.h"
 }
 

--- a/src/impala/impala.h
+++ b/src/impala/impala.h
@@ -55,21 +55,10 @@ enum Prec {
     Unary,
 };
 
-typedef Prec Type2Prec[Token::Num_Tokens];
-
-struct BinPrec {
-    Prec l;
-    Prec r;
-
-    BinPrec() {}
-    BinPrec(Prec l, Prec r) : l(l), r(r) {}
-};
-
-typedef BinPrec Type2BinPrec[Token::Num_Tokens];
-
 struct PrecTable {
-    static Type2Prec infix_l;  ///< Left precedences -- for binary operators.
-    static Type2Prec infix_r;  ///< Right precedences -- for binary operators.
+    static Prec infix[Token::Num_Tokens];
+    static Prec infix_l(int tag) { return infix[tag]; }
+    static Prec infix_r(int tag) { return Prec(infix[tag]+1); }
 
 private:
     static void init();

--- a/src/impala/impala.h
+++ b/src/impala/impala.h
@@ -44,7 +44,7 @@ void type_analysis(const Module*, bool nossa);
 void check(Init&, const Module*, bool nossa);
 void emit(thorin::World&, const Module*);
 
-enum Prec {
+enum class Prec {
     Bottom,
     Assign = Bottom,
     OrOr, AndAnd,
@@ -58,7 +58,7 @@ enum Prec {
 struct PrecTable {
     static Prec infix[Token::Num_Tokens];
     static Prec infix_l(int tag) { return infix[tag]; }
-    static Prec infix_r(int tag) { return Prec(infix[tag]+1); }
+    static Prec infix_r(int tag) { return Prec(int(infix[tag])+1); }
 
 private:
     static void init();

--- a/src/impala/impala.h
+++ b/src/impala/impala.h
@@ -48,13 +48,11 @@ enum Prec {
     Bottom,
     Assign = Bottom,
     OrOr, AndAnd,
-    Eq, Rel,
+    Rel,
     Or, Xor, And,
     Shift, Add, Mul,
-    Unary,
-    Eval,
     As,
-    Postfix,
+    Unary,
 };
 
 typedef Prec Type2Prec[Token::Num_Tokens];
@@ -70,10 +68,8 @@ struct BinPrec {
 typedef BinPrec Type2BinPrec[Token::Num_Tokens];
 
 struct PrecTable {
-    static Type2Prec prefix_r; ///< Right precedence -- for unary prefix operators.
     static Type2Prec infix_l;  ///< Left precedences -- for binary operators.
     static Type2Prec infix_r;  ///< Right precedences -- for binary operators.
-    static Type2Prec postfix_l;///< Left precedence -- for unary postfix operators.
 
 private:
     static void init();

--- a/src/impala/impala.h
+++ b/src/impala/impala.h
@@ -56,7 +56,7 @@ enum class Prec {
 };
 
 struct PrecTable {
-    static Prec infix[Token::Num_Tokens];
+    static Prec infix[Token::Num];
     static Prec infix_l(int tag) { return infix[tag]; }
     static Prec infix_r(int tag) { return Prec(int(infix[tag])+1); }
 

--- a/src/impala/lexer.cpp
+++ b/src/impala/lexer.cpp
@@ -54,7 +54,7 @@ Token Lexer::lex() {
 
         // end of file
         if (accept(std::istream::traits_type::eof()))
-            return {location(), Token::END_OF_FILE};
+            return {location(), Token::Eof};
 
         // skip whitespace
         if (accept(space)) {
@@ -113,7 +113,7 @@ Token Lexer::lex() {
         while (true) { \
             if (accept(std::istream::traits_type::eof())) { \
                 error(location().front(), "unterminated comment"); \
-                return {location(), Token::END_OF_FILE}; \
+                return {location(), Token::Eof}; \
             } \
             if (delim) break; \
             next(); /* eat up char in comment */\
@@ -274,14 +274,14 @@ Token Lexer::lex_suffix(std::string& str, bool floating) {
         Symbol suffix(suffix_str);
         if (floating) {
             auto lit = Token::sym2flit(suffix);
-            if (lit == Token::TYPE_error) {
+            if (lit == Token::Error) {
                 error(location(), "invalid suffix on floating constant '{}'", suffix);
                 return {location(), tok, str};
             }
             tok = lit;
         } else {
             auto lit = Token::sym2lit(suffix);
-            if (lit == Token::TYPE_error) {
+            if (lit == Token::Error) {
                 error(location(), "invalid suffix on constant '{}'", suffix);
                 return {location(), tok, str};
             }

--- a/src/impala/parser.cpp
+++ b/src/impala/parser.cpp
@@ -234,7 +234,7 @@ public:
 
     // expressions
     const Expr*             parse_expr(Prec prec);
-    const Expr*             parse_expr() { return parse_expr(Bottom); }
+    const Expr*             parse_expr() { return parse_expr(Prec::Bottom); }
     const Expr*             parse_prefix_expr();
     const Expr*             parse_infix_expr(Tracker, const Expr* lhs);
     const Expr*             parse_postfix_expr(Tracker, const Expr* lhs);

--- a/src/impala/parser.cpp
+++ b/src/impala/parser.cpp
@@ -115,7 +115,6 @@ public:
     Parser(std::istream& stream, const char* filename)
         : lexer_(stream, filename)
         , cur_var_handle(2) // reserve 1 for conditionals, 0 for mem
-        , no_bars_(false)
     {
         lookahead_[0] = lexer_.lex();
         lookahead_[1] = lexer_.lex();
@@ -234,10 +233,8 @@ public:
     const Typedef*     parse_typedef(Tracker, Visibility);
 
     // expressions
-    bool is_infix();
     const Expr*             parse_expr(Prec prec);
-    const Expr*             parse_expr() { return parse_expr(Bottom, false); }
-    const Expr*             parse_expr(Prec prec, bool no_bars) { THORIN_PUSH(no_bars_, no_bars); return parse_expr(prec); }
+    const Expr*             parse_expr() { return parse_expr(Bottom); }
     const Expr*             parse_prefix_expr();
     const Expr*             parse_infix_expr(Tracker, const Expr* lhs);
     const Expr*             parse_postfix_expr(Tracker, const Expr* lhs);
@@ -283,7 +280,6 @@ private:
     Lexer lexer_;        ///< invoked in order to get next token
     Token lookahead_[3]; ///< SLL(3) look ahead
     size_t cur_var_handle;
-    bool no_bars_;
     Location prev_location_;
 };
 
@@ -840,13 +836,6 @@ const SimdASTType* Parser::parse_simd_type() {
  * expressions
  */
 
-bool Parser::is_infix() {
-    bool infix = lookahead().is_infix();
-    if (no_bars_ && infix)
-        return lookahead() != Token::OR && lookahead() != Token::OROR;
-    return infix;
-}
-
 const Expr* Parser::parse_expr(Prec prec) {
     auto tracker = track();
     auto lhs = lookahead().is_prefix() ? parse_prefix_expr() : parse_primary_expr();
@@ -860,8 +849,8 @@ const Expr* Parser::parse_expr(Prec prec) {
          *  lhs  op (LA  op ...) otherwise                                  -->  shift
          */
 
-        if (is_infix()) {
-            if (prec > PrecTable::infix_l[lookahead()])
+        if (lookahead().is_infix()) {
+            if (prec > PrecTable::infix_l(lookahead()))
                 break;
 
             lhs = parse_infix_expr(tracker, lhs);
@@ -893,7 +882,7 @@ const Expr* Parser::parse_infix_expr(Tracker tracker, const Expr* lhs) {
     auto tag = lex().tag();
     if (tag == Token::AS)
         return new ExplicitCastExpr(tracker, lhs, parse_type());
-    auto rhs = parse_expr(PrecTable::infix_r[tag]);
+    auto rhs = parse_expr(PrecTable::infix_r(tag));
     return new InfixExpr(tracker, lhs, (InfixExpr::Tag) tag, rhs);
 }
 

--- a/src/impala/parser.cpp
+++ b/src/impala/parser.cpp
@@ -288,7 +288,7 @@ private:
 void parse(Items& items, std::istream& is, const char* filename) {
     Parser parser(is, filename);
     parser.parse_items(items);
-    if (parser.lookahead() != Token::END_OF_FILE)
+    if (parser.lookahead() != Token::Eof)
         parser.error("module item", "module contents");
 }
 

--- a/src/impala/sema/infersema.cpp
+++ b/src/impala/sema/infersema.cpp
@@ -695,6 +695,8 @@ const Type* InfixExpr::infer(InferSema& sema) const {
             sema.assign(lhs(), rhs());
             return sema.unit();
         }
+        case AS:
+            THORIN_UNREACHABLE;
     }
 
     THORIN_UNREACHABLE;

--- a/src/impala/stream.cpp
+++ b/src/impala/stream.cpp
@@ -5,7 +5,7 @@ namespace impala {
 
 using namespace thorin;
 
-Prec prec = Bottom;
+Prec prec = Prec::Bottom;
 
 /*
  * AST types

--- a/src/impala/stream.cpp
+++ b/src/impala/stream.cpp
@@ -323,7 +323,7 @@ std::ostream& PrefixExpr::stream(std::ostream& os) const {
 }
 
 std::ostream& InfixExpr::stream(std::ostream& os) const {
-    auto open_state = open(os, PrecTable::infix_l[tag()]);
+    auto open_state = open(os, PrecTable::infix_l(tag()));
     const char* op;
     switch (tag()) {
 #define IMPALA_INFIX_ASGN(tok, str)       case tok: op = str; break;
@@ -332,7 +332,7 @@ std::ostream& InfixExpr::stream(std::ostream& os) const {
     }
 
     os << lhs() << " " << op << " ";
-    prec = PrecTable::infix_r[tag()];
+    prec = PrecTable::infix_r(tag());
     os << rhs();
     return close(os, open_state);
 }

--- a/src/impala/stream.cpp
+++ b/src/impala/stream.cpp
@@ -285,32 +285,8 @@ std::ostream& SimdExpr::stream(std::ostream& os) const {
     return stream_list(os, args(), [&](const auto& expr) { os << expr.get(); }, "simd[", "]");
 }
 
-std::ostream& PrefixExpr::stream(std::ostream& os) const {
-    Prec r = PrecTable::prefix_r[tag()];
-    Prec old = prec;
-    bool paren = !fancy() || prec <= r;
-    if (paren) os << "(";
-
-    const char* op;
-    switch (tag()) {
-#define IMPALA_PREFIX(tok, str, rprec) case tok: op = str; break;
-#include "impala/tokenlist.h"
-        case MUT: op = "&mut "; break;
-        default: THORIN_UNREACHABLE;
-    }
-
-    os << op;
-    prec = r;
-    os << rhs();
-    prec = old;
-
-    if (paren) os << ")";
-    return os;
-}
-
-static std::pair<Prec, bool> open(std::ostream& os, int tag) {
+static std::pair<Prec, bool> open(std::ostream& os, Prec l) {
     std::pair<Prec, bool> result;
-    Prec l = PrecTable::postfix_l[tag];
     result.first = prec;
     result.second = !fancy() || prec > l;
     if (result.second)
@@ -326,12 +302,32 @@ static std::ostream& close(std::ostream& os, std::pair<Prec, bool> pair) {
     return os;
 }
 
-std::ostream& InfixExpr::stream(std::ostream& os) const {
-    auto open_state = open(os, tag());
+std::ostream& PrefixExpr::stream(std::ostream& os) const {
     const char* op;
     switch (tag()) {
-#define IMPALA_INFIX_ASGN(tok, str, lprec, rprec) case tok: op = str; break;
-#define IMPALA_INFIX(     tok, str, lprec, rprec) case tok: op = str; break;
+#define IMPALA_PREFIX(tok, str) case tok: op = str; break;
+#include "impala/tokenlist.h"
+        case MUT: op = "&mut "; break;
+        default: THORIN_UNREACHABLE;
+    }
+
+    os << op;
+    if (auto prefix_expr = rhs()->isa<PrefixExpr>()) {
+        if ((tag() == ADD || tag() == SUB) && tag() == prefix_expr->tag())
+            os << ' ';
+    }
+
+    auto open_state = open(os, Prec::Unary);
+    os << rhs();
+    return close(os, open_state);
+}
+
+std::ostream& InfixExpr::stream(std::ostream& os) const {
+    auto open_state = open(os, PrecTable::infix_l[tag()]);
+    const char* op;
+    switch (tag()) {
+#define IMPALA_INFIX_ASGN(tok, str)       case tok: op = str; break;
+#define IMPALA_INFIX(     tok, str, prec) case tok: op = str; break;
 #include "impala/tokenlist.h"
     }
 
@@ -342,7 +338,7 @@ std::ostream& InfixExpr::stream(std::ostream& os) const {
 }
 
 std::ostream& PostfixExpr::stream(std::ostream& os) const {
-    auto open_state = open(os, tag());
+    auto open_state = open(os, Prec::Unary);
     const char* op;
     switch (tag()) {
         case INC: op = "++"; break;
@@ -355,25 +351,25 @@ std::ostream& PostfixExpr::stream(std::ostream& os) const {
 }
 
 std::ostream& FieldExpr::stream(std::ostream& os) const {
-    auto open_state = open(os, Token::DOT);
+    auto open_state = open(os, Prec::Unary);
     os << lhs() << '.' << symbol();
     return close(os, open_state);
 }
 
 std::ostream& ExplicitCastExpr::stream(std::ostream& os) const {
-    auto open_state = open(os, Token::AS);
+    auto open_state = open(os, Prec::As);
     streamf(os, "{} as {}", src(), ast_type());
     return close(os, open_state);
 }
 
 std::ostream& ImplicitCastExpr::stream(std::ostream& os) const {
-    auto open_state = open(os, Token::AS);
+    auto open_state = open(os, Prec::As);
     streamf(os, "implicit_cast({}, {})", src(), type());
     return close(os, open_state);
 }
 
 std::ostream& Ref2ValueExpr::stream(std::ostream& os) const {
-    auto open_state = open(os, Token::AS);
+    auto open_state = open(os, Prec::As);
     streamf(os, "ref2value({}, {})", src(), type());
     return close(os, open_state);
 }
@@ -388,7 +384,7 @@ std::ostream& StructExpr::stream(std::ostream& os) const {
 }
 
 std::ostream& TypeAppExpr::stream(std::ostream& os) const {
-    Prec l = PrecTable::postfix_l[Token::L_BRACKET];
+    Prec l = Prec::Unary;
     Prec old = prec;
     bool paren = !fancy() || prec > l;
     if (paren) os << "(";
@@ -406,7 +402,7 @@ std::ostream& TypeAppExpr::stream(std::ostream& os) const {
 }
 
 std::ostream& MapExpr::stream(std::ostream& os) const {
-    Prec l = PrecTable::postfix_l[Token::L_PAREN];
+    Prec l = Prec::Unary;
     Prec old = prec;
     bool paren = !fancy() || prec > l;
     if (paren) os << "(";

--- a/src/impala/token.cpp
+++ b/src/impala/token.cpp
@@ -202,10 +202,10 @@ void Token::init() {
     for (size_t i = 0; i < Num_Tokens; ++i)
         tok2op_[i] = None;
 
-#define IMPALA_PREFIX(    tok, str, r   ) insert(tok, str); tok2op_[tok] |= Prefix;
-#define IMPALA_POSTFIX(   tok, str,    l) insert(tok, str); tok2op_[tok] |= Postfix;
-#define IMPALA_INFIX(     tok, str, r, l) insert(tok, str); tok2op_[tok] |= Infix;
-#define IMPALA_INFIX_ASGN(tok, str, r, l) insert(tok, str); tok2op_[tok] |= Infix | Asgn_Op;
+#define IMPALA_PREFIX(    tok, str)       insert(tok, str); tok2op_[tok] |= Prefix;
+#define IMPALA_POSTFIX(   tok, str)       insert(tok, str); tok2op_[tok] |= Postfix;
+#define IMPALA_INFIX(     tok, str, prec) insert(tok, str); tok2op_[tok] |= Infix;
+#define IMPALA_INFIX_ASGN(tok, str)       insert(tok, str); tok2op_[tok] |= Infix | Asgn_Op;
 #define IMPALA_MISC(      tok, str)       insert(tok, str);
 #define IMPALA_KEY(       tok, str)       insert_key(tok, str);
 #define IMPALA_LIT(       tok, atype)     tok2str_[LIT_##tok] = Symbol("<literal>").str();
@@ -235,6 +235,7 @@ void Token::init() {
     // special tokens
     tok2str_[ID]         = Symbol("<identifier>").str();
     insert(END_OF_FILE, "<end of file>");
+    insert_key(AS, "as");
     insert_key(MUT, "mut");
 }
 

--- a/src/impala/token.cpp
+++ b/src/impala/token.cpp
@@ -164,7 +164,7 @@ int Token::to_binop(Tag tag) {
  * static member variables
  */
 
-int Token::tok2op_[Num_Tokens];
+int Token::tok2op_[Num];
 Token::Tag2Str Token::tok2str_;
 Token::Tag2Sym Token::tok2sym_;
 Token::Sym2Tag Token::keywords_;
@@ -179,14 +179,14 @@ TokenTag Token::sym2lit(Symbol sym) {
     auto i = sym2lit_.find(sym);
     if (i != sym2lit_.end())
         return i->second;
-    return TYPE_error;
+    return Error;
 }
 
 TokenTag Token::sym2flit(Symbol sym) {
     auto i = sym2flit_.find(sym);
     if (i != sym2flit_.end())
         return i->second;
-    return TYPE_error;
+    return Error;
 }
 
 void Token::init() {
@@ -199,7 +199,7 @@ void Token::init() {
      * - register misc tokens
      */
 
-    for (size_t i = 0; i < Num_Tokens; ++i)
+    for (size_t i = 0; i < Num; ++i)
         tok2op_[i] = None;
 
 #define IMPALA_PREFIX(    tok, str)       insert(tok, str); tok2op_[tok] |= Prefix;
@@ -234,7 +234,7 @@ void Token::init() {
 
     // special tokens
     tok2str_[ID]         = Symbol("<identifier>").str();
-    insert(END_OF_FILE, "<end of file>");
+    insert(Eof, "<end of file>");
     insert_key(AS, "as");
     insert_key(MUT, "mut");
 }

--- a/src/impala/token.h
+++ b/src/impala/token.h
@@ -18,8 +18,8 @@ public:
     enum Tag {
         // !!! DO NOT CHANGE THIS ORDER !!!
         // add prefix and postfix tokens manually in order to avoid duplicates in the enum
-#define IMPALA_INFIX(     tok, t_str, r, l) tok,
-#define IMPALA_INFIX_ASGN(tok, t_str, r, l) tok,
+#define IMPALA_INFIX(     tok, t_str, prec) tok,
+#define IMPALA_INFIX_ASGN(tok, t_str)       tok,
 #define IMPALA_KEY(       tok, t_str)       tok,
 #define IMPALA_MISC(      tok, t_str)       tok,
 #define IMPALA_LIT(       tok, t)           LIT_##tok,

--- a/src/impala/token.h
+++ b/src/impala/token.h
@@ -29,17 +29,15 @@ public:
         // manually insert missing unary prefix/postfix types
         TILDE, NOT, INC, DEC, RUN, HLT, DOT,
         // these do ont appear in impala/tokenlist.h -- they are too special
-        MUT, ID, END_OF_FILE,
-        TYPE_app, TYPE_generic, TYPE_genericref, TYPE_error, TYPE_tuple, TYPE_definite_array, TYPE_indefinite_array,
+        MUT, ID, Eof, Error,
         LIT_char, LIT_str,
-        Num_Tokens,
-        Sentinel,
+        Num,
     };
 
     struct TagHash {
         static uint64_t hash(Tag tag) { return uint64_t(tag); }
         static bool eq(Tag k1, Tag k2) { return k1 == k2; }
-        static Tag sentinel() { return Sentinel; }
+        static Tag sentinel() { return Num; }
     };
 
     Token() {}
@@ -101,7 +99,7 @@ private:
     typedef thorin::HashMap<Symbol, Tag> Sym2Tag;
     typedef thorin::HashMap<Tag, const char*, TagHash> Tag2Str;
     typedef thorin::HashMap<Tag, Symbol, TagHash> Tag2Sym;
-    static int tok2op_[Num_Tokens];
+    static int tok2op_[Num];
     static Tag2Str tok2str_;
     static Tag2Sym tok2sym_;
     static Sym2Tag keywords_;

--- a/src/impala/tokenlist.h
+++ b/src/impala/tokenlist.h
@@ -1,75 +1,75 @@
 #ifndef IMPALA_PREFIX
-#define IMPALA_PREFIX(tok, str, prec)
+#define IMPALA_PREFIX(tok, str)
 #endif
 
-IMPALA_PREFIX(  ADD,   "+", Postfix) // unary +
-IMPALA_PREFIX(  SUB,   "-", Postfix) // unary -
-IMPALA_PREFIX(  MUL,   "*", Postfix) // deref
-IMPALA_PREFIX(  AND,   "&", Postfix) // address of
-IMPALA_PREFIX(TILDE,   "~", Postfix) // owned ptr constructor
-IMPALA_PREFIX(  NOT,   "!", Postfix) // not
-IMPALA_PREFIX(  INC,  "++", Postfix) // prefix ++
-IMPALA_PREFIX(  DEC,  "--", Postfix) // prefix --
-IMPALA_PREFIX(   OR,   "|", Postfix) // lambda expressions
-IMPALA_PREFIX( OROR,  "||", Postfix) // lambda expressions with empty param list
-IMPALA_PREFIX(  RUN,   "@",    Eval) // trigger partial evaluation
-IMPALA_PREFIX(  HLT,   "$",    Eval) // stop partial evaluation
+IMPALA_PREFIX(  ADD,   "+") // unary +
+IMPALA_PREFIX(  SUB,   "-") // unary -
+IMPALA_PREFIX(  MUL,   "*") // deref
+IMPALA_PREFIX(  AND,   "&") // address of
+IMPALA_PREFIX(TILDE,   "~") // owned ptr constructor
+IMPALA_PREFIX(  NOT,   "!") // not
+IMPALA_PREFIX(  INC,  "++") // prefix ++
+IMPALA_PREFIX(  DEC,  "--") // prefix --
+IMPALA_PREFIX(   OR,   "|") // lambda expressions
+IMPALA_PREFIX( OROR,  "||") // lambda expressions with empty param list
+IMPALA_PREFIX(  RUN,   "@") // trigger partial evaluation
+IMPALA_PREFIX(  HLT,   "$") // stop partial evaluation
 
 #undef IMPALA_PREFIX
 
 #ifndef IMPALA_POSTFIX
-#define IMPALA_POSTFIX(tok, str, prec)
+#define IMPALA_POSTFIX(tok, str)
 #endif
 
-IMPALA_POSTFIX(      INC, "++", Postfix) // postfix ++
-IMPALA_POSTFIX(      DEC, "--", Postfix) // postfix --
-IMPALA_POSTFIX(L_BRACKET,  "[", Postfix) // MapExpr with type argument list
-IMPALA_POSTFIX(  L_PAREN,  "(", Postfix) // MapExpr (function call, array/tuple index)
-IMPALA_POSTFIX(      DOT,  ".", Postfix) // FieldExpr
-IMPALA_POSTFIX(       AS, "as",      As) // CastExpr
+IMPALA_POSTFIX(      INC, "++") // postfix ++
+IMPALA_POSTFIX(      DEC, "--") // postfix --
+IMPALA_POSTFIX(L_BRACKET,  "[") // MapExpr with type argument list
+IMPALA_POSTFIX(  L_PAREN,  "(") // MapExpr (function call, array/tuple index)
+IMPALA_POSTFIX(      DOT,  ".") // FieldExpr
 
 #undef IMPALA_POSTFIX
 
 #ifndef IMPALA_INFIX_ASGN
-#define IMPALA_INFIX_ASGN(tok, str, lprec, rprec)
+#define IMPALA_INFIX_ASGN(tok, str)
 #endif
 
-IMPALA_INFIX_ASGN(    ASGN,   "=", OrOr, Assign)
-IMPALA_INFIX_ASGN(ADD_ASGN,  "+=", OrOr, Assign)
-IMPALA_INFIX_ASGN(SUB_ASGN,  "-=", OrOr, Assign)
-IMPALA_INFIX_ASGN(MUL_ASGN,  "*=", OrOr, Assign)
-IMPALA_INFIX_ASGN(DIV_ASGN,  "/=", OrOr, Assign)
-IMPALA_INFIX_ASGN(REM_ASGN,  "%=", OrOr, Assign)
-IMPALA_INFIX_ASGN(AND_ASGN,  "&=", OrOr, Assign)
-IMPALA_INFIX_ASGN( OR_ASGN,  "|=", OrOr, Assign)
-IMPALA_INFIX_ASGN(XOR_ASGN,  "^=", OrOr, Assign)
-IMPALA_INFIX_ASGN(SHL_ASGN, "<<=", OrOr, Assign)
-IMPALA_INFIX_ASGN(SHR_ASGN, ">>=", OrOr, Assign)
+IMPALA_INFIX_ASGN(    ASGN,   "=")
+IMPALA_INFIX_ASGN(ADD_ASGN,  "+=")
+IMPALA_INFIX_ASGN(SUB_ASGN,  "-=")
+IMPALA_INFIX_ASGN(MUL_ASGN,  "*=")
+IMPALA_INFIX_ASGN(DIV_ASGN,  "/=")
+IMPALA_INFIX_ASGN(REM_ASGN,  "%=")
+IMPALA_INFIX_ASGN(AND_ASGN,  "&=")
+IMPALA_INFIX_ASGN( OR_ASGN,  "|=")
+IMPALA_INFIX_ASGN(XOR_ASGN,  "^=")
+IMPALA_INFIX_ASGN(SHL_ASGN, "<<=")
+IMPALA_INFIX_ASGN(SHR_ASGN, ">>=")
 
 #undef IMPALA_INFIX_ASGN
 
 #ifndef IMPALA_INFIX
-#define IMPALA_INFIX(tok, str, lprec, rprec)
+#define IMPALA_INFIX(tok, str, prec)
 #endif
 
-IMPALA_INFIX(  OROR, "||",   OrOr, AndAnd)
-IMPALA_INFIX(ANDAND, "&&", AndAnd,     Eq)
-IMPALA_INFIX(    EQ, "==",     Eq,    Rel)
-IMPALA_INFIX(    NE, "!=",     Eq,    Rel)
-IMPALA_INFIX(    LT,  "<",    Rel,     Or)
-IMPALA_INFIX(    LE, "<=",    Rel,     Or)
-IMPALA_INFIX(    GT,  ">",    Rel,     Or)
-IMPALA_INFIX(    GE, ">=",    Rel,     Or)
-IMPALA_INFIX(    OR,  "|",     Or,    Xor)
-IMPALA_INFIX(   XOR,  "^",    Xor,    And)
-IMPALA_INFIX(   AND,  "&",    And,  Shift)
-IMPALA_INFIX(   SHL, "<<",  Shift,    Add)
-IMPALA_INFIX(   SHR, ">>",  Shift,    Add)
-IMPALA_INFIX(   ADD,  "+",    Add,    Mul)
-IMPALA_INFIX(   SUB,  "-",    Add,    Mul)
-IMPALA_INFIX(   MUL,  "*",    Mul,  Unary)
-IMPALA_INFIX(   DIV,  "/",    Mul,  Unary)
-IMPALA_INFIX(   REM,  "%",    Mul,  Unary)
+IMPALA_INFIX(  OROR, "||",   OrOr)
+IMPALA_INFIX(ANDAND, "&&", AndAnd)
+IMPALA_INFIX(    EQ, "==",    Rel)
+IMPALA_INFIX(    NE, "!=",    Rel)
+IMPALA_INFIX(    LT,  "<",    Rel)
+IMPALA_INFIX(    LE, "<=",    Rel)
+IMPALA_INFIX(    GT,  ">",    Rel)
+IMPALA_INFIX(    GE, ">=",    Rel)
+IMPALA_INFIX(    OR,  "|",     Or)
+IMPALA_INFIX(   XOR,  "^",    Xor)
+IMPALA_INFIX(   AND,  "&",    And)
+IMPALA_INFIX(   SHL, "<<",  Shift)
+IMPALA_INFIX(   SHR, ">>",  Shift)
+IMPALA_INFIX(   ADD,  "+",    Add)
+IMPALA_INFIX(   SUB,  "-",    Add)
+IMPALA_INFIX(   MUL,  "*",    Mul)
+IMPALA_INFIX(   DIV,  "/",    Mul)
+IMPALA_INFIX(   REM,  "%",    Mul)
+IMPALA_INFIX(    AS, "as",     As)
 
 #undef IMPALA_INFIX
 
@@ -77,7 +77,6 @@ IMPALA_INFIX(   REM,  "%",    Mul,  Unary)
 #define IMPALA_KEY(tok, str)
 #endif
 
-IMPALA_KEY(AS,        "as")
 IMPALA_KEY(DO,        "do")
 IMPALA_KEY(ELSE,      "else")
 IMPALA_KEY(ENUM,      "enum")


### PR DESCRIPTION
This puts `==` and `!=` at the same precedence as `<`, `<=`, `>` and `>=`.
Rust does the same. Differentiating between those two precedence levels causes more confusion than that it helps.

Furthermore, I cleaned up a lot of the precedence code and also fixed some `--fancy` bugs in impala's ast dump.