### PR TITLE
Enums

### DIFF
--- a/src/impala/ast.cpp
+++ b/src/impala/ast.cpp
@@ -140,6 +140,10 @@ bool IdPtrn::is_refutable() const {
     return false;
 }
 
+bool EnumPtrn::is_refutable() const {
+    return true;
+}
+
 bool LiteralPtrn::is_refutable() const {
     return true;
 }

--- a/src/impala/ast.h
+++ b/src/impala/ast.h
@@ -919,6 +919,7 @@ public:
 private:
     const Type* infer(InferSema&) const;
     void check(TypeSema&) const;
+    thorin::Value emit(CodeGen&, const thorin::Def* init) const override;
 
     uint32_t index_;
     ASTTypes args_;
@@ -1290,7 +1291,9 @@ public:
     {}
 
     const Path* path() const { return path_.get(); }
-    const Decl* value_decl() const { return path_->decl(); }
+    const Decl* value_decl() const {
+        return path_->decl() && path_->decl()->is_value_decl() ? path_->decl() : nullptr;
+    }
 
     void write() const override;
     void take_address() const override;

--- a/src/impala/ast.h
+++ b/src/impala/ast.h
@@ -228,6 +228,8 @@ public:
 
     bool is_global() const { return global_; }
     const Elems& elems() const { return elems_; }
+    const Elem* elem(size_t i) const { return elems_[i].get(); }
+    size_t num_elems() const { return elems_.size(); }
     const Decl* decl() const { return elems().back()->decl(); }
     void bind(NameSema&) const;
     std::ostream& stream(std::ostream&) const override;
@@ -890,7 +892,7 @@ private:
 class OptionDecl : public Decl {
 public:
     OptionDecl(Location location, size_t index, const Identifier* id, ASTTypes args)
-        : Decl(TypeableDecl, location, id)
+        : Decl(ValueDecl, location, id)
         , index_(index)
         , args_(std::move(args))
     {}
@@ -899,6 +901,7 @@ public:
     size_t num_args() const { return args_.size(); }
     const ASTTypes& args() const { return args_; }
     const ASTType* arg(size_t i) const { return args_[i].get(); }
+    const EnumDecl* enum_decl() const { return enum_decl_; }
 
     void bind(NameSema&) const;
     std::ostream& stream(std::ostream&) const override;
@@ -910,6 +913,9 @@ private:
     uint32_t index_;
     ASTTypes args_;
 
+    mutable const EnumDecl* enum_decl_;
+
+    friend class EnumDecl;
     friend class InferSema;
     friend class TypeSema;
 };

--- a/src/impala/emit.cpp
+++ b/src/impala/emit.cpp
@@ -85,6 +85,7 @@ public:
 
     void convert_ops(const Type*, std::vector<const thorin::Type*>& nops);
     const thorin::Type* convert_rec(const Type*);
+    size_t bitwidth(const Type* t);
 
     const thorin::Type*& thorin_type(const Type* type) { return impala2thorin_[type]; }
     const thorin::StructType*& thorin_struct_type(const StructType* type) { return struct_type_impala2thorin_[type]; }
@@ -134,7 +135,12 @@ const thorin::Type* CodeGen::convert_rec(const Type* type) {
         thorin_type(type) = nullptr; // will be set again by CodeGen's wrapper
         return thorin_struct_type(struct_type);
     } else if (auto enum_type = type->isa<EnumType>()) {
-        THORIN_UNREACHABLE;
+        std::vector<const thorin::Type*> ops;
+        ops.push_back(world().type_qu32());
+        size_t bytes = (bitwidth(enum_type) - 32) / 8;
+        if (bytes != 0)
+            ops.push_back(world().definite_array_type(world().type_qu8(), bytes));
+        return world().tuple_type(ops);
     } else if (auto ptr_type = type->isa<PtrType>()) {
         return world().ptr_type(convert(ptr_type->pointee()), 1, -1, thorin::AddrSpace(ptr_type->addr_space()));
     } else if (auto definite_array_type = type->isa<DefiniteArrayType>()) {
@@ -143,6 +149,47 @@ const thorin::Type* CodeGen::convert_rec(const Type* type) {
         return world().indefinite_array_type(convert(indefinite_array_type->elem_type()));
     } else if (auto simd_type = type->isa<SimdType>()) {
         return world().type(convert(simd_type->elem_type())->as<thorin::PrimType>()->primtype_tag(), simd_type->dim());
+    }
+    THORIN_UNREACHABLE;
+}
+
+size_t CodeGen::bitwidth(const Type* t) {
+    if (auto tuple_type = t->isa<TupleType>()) {
+        size_t bits = 0;
+        for (const auto& op : tuple_type->ops()) bits += bitwidth(op);
+        return bits;
+    } else if (auto enum_type = t->isa<EnumType>()) {
+        size_t bits = 0;
+        for (const auto & op : enum_type->ops()) {
+            size_t op_bits = 0;
+            if (auto fn_type = op->isa<FnType>()) {
+                for (size_t i = 0, e = fn_type->num_ops() - 1; i != e; i++)
+                    op_bits += bitwidth(fn_type->op(i));
+            } else {
+                op_bits = 0;
+            }
+            bits = std::max(bits, op_bits);
+        }
+        return 32 + bits;
+    } else if (auto prim_type = t->isa<PrimType>()) {
+        switch (prim_type->primtype_tag()) {
+            case PrimType_i8:  return 8;
+            case PrimType_i16: return 16;
+            case PrimType_i32: return 32;
+            case PrimType_i64: return 64;
+            case PrimType_u8:  return 8;
+            case PrimType_u16: return 16;
+            case PrimType_u32: return 32;
+            case PrimType_u64: return 64;
+            case PrimType_f16: return 16;
+            case PrimType_f32: return 32;
+            case PrimType_f64: return 64;
+
+            case PrimType_bool:
+                // cannot reliably estimate the type of a boolean (LLVM will do its own stuff)
+            default:
+              THORIN_UNREACHABLE;
+        }
     }
     THORIN_UNREACHABLE;
 }
@@ -169,6 +216,13 @@ Value LocalDecl::emit(CodeGen& cg, const Def* init) const {
         value_ = Value::create_val(cg, init);
 
     return value_;
+}
+
+const thorin::Type* OptionDecl::variant_type(CodeGen& cg) const {
+    std::vector<const thorin::Type*> types;
+    for (const auto& arg : args())
+        types.push_back(cg.convert(arg->type()));
+    return cg.world().tuple_type(types);
 }
 
 Continuation* Fn::emit_head(CodeGen& cg, Location location) const {
@@ -622,6 +676,20 @@ const Def* MapExpr::remit(CodeGen& cg, State state, Location eval_loc) const {
             }
         }
 
+        if (auto path_expr = lhs()->isa<PathExpr>()) {
+            if (auto option = path_expr->path()->decl()->isa<OptionDecl>()) {
+                // handle option creation here
+                auto variant_type = option->variant_type(cg);
+                std::vector<const Def*> defs;
+                for (const auto& arg : args())
+                    defs.push_back(cg.remit(arg.get()));
+                return cg.world().tuple({
+                    cg.world().literal_qu32(option->index(), location()),
+                    cg.world().bitcast(variant_type, cg.world().tuple(defs, location()), location())
+                });
+            }
+        }
+
         dst = dst ? dst : cg.remit(lhs());
 
         std::vector<const Def*> defs;
@@ -838,6 +906,29 @@ void IdPtrn::emit(CodeGen& cg, const thorin::Def* init) const {
 
 const thorin::Def* IdPtrn::emit_cond(CodeGen& cg, const thorin::Def*) const {
     return cg.world().literal(true);
+}
+
+void EnumPtrn::emit(CodeGen& cg, const thorin::Def* init) const {
+    if (num_args() == 0) return;
+    auto variant_type = path()->decl()->as<OptionDecl>()->variant_type(cg);
+    auto variant = cg.world().bitcast(variant_type, cg.world().extract(init, 1), location());
+    for (size_t i = 0, e = num_args(); i != e; ++i) {
+        cg.emit(arg(i), cg.extract(variant, i, location()));
+    }
+}
+
+const thorin::Def* EnumPtrn::emit_cond(CodeGen& cg, const thorin::Def* init) const {
+    auto index = path()->decl()->as<OptionDecl>()->index();
+    auto cond = cg.world().cmp_eq(cg.world().extract(init, size_t(0), location()), cg.world().literal_qu32(index, location()));
+    if (num_args() > 0) {
+        auto variant_type = path()->decl()->as<OptionDecl>()->variant_type(cg);
+        auto variant = cg.world().bitcast(variant_type, cg.world().extract(init, 1, location()), location());
+        for (size_t i = 0, e = num_args(); i != e; ++i) {
+            if (!arg(i)->is_refutable()) continue;
+            cond = cg.world().arithop_and(cond, arg(i)->emit_cond(cg, cg.world().extract(variant, i, location())), location());
+        }
+    }
+    return cond;
 }
 
 void TuplePtrn::emit(CodeGen& cg, const thorin::Def* init) const {

--- a/src/impala/emit.cpp
+++ b/src/impala/emit.cpp
@@ -133,6 +133,8 @@ const thorin::Type* CodeGen::convert_rec(const Type* type) {
             thorin_struct_type(struct_type)->set(i++, convert(op));
         thorin_type(type) = nullptr; // will be set again by CodeGen's wrapper
         return thorin_struct_type(struct_type);
+    } else if (auto enum_type = type->isa<EnumType>()) {
+        THORIN_UNREACHABLE;
     } else if (auto ptr_type = type->isa<PtrType>()) {
         return world().ptr_type(convert(ptr_type->pointee()), 1, -1, thorin::AddrSpace(ptr_type->addr_space()));
     } else if (auto definite_array_type = type->isa<DefiniteArrayType>()) {
@@ -294,6 +296,10 @@ Value StaticItem::emit(CodeGen& cg, const Def* init) const {
 }
 
 void StructDecl::emit(CodeGen& cg) const {
+    cg.convert(type());
+}
+
+void EnumDecl::emit(CodeGen& cg) const {
     cg.convert(type());
 }
 

--- a/src/impala/parser.cpp
+++ b/src/impala/parser.cpp
@@ -500,6 +500,7 @@ const Item* Parser::parse_item() {
 }
 
 const EnumDecl* Parser::parse_enum_decl(Tracker tracker, Visibility vis) {
+    eat(Token::ENUM);
     auto identifier = try_identifier("enum declaration");
     auto ast_type_params = parse_ast_type_params();
     expect(Token::L_BRACE, "enum declaration");

--- a/src/impala/parser.cpp
+++ b/src/impala/parser.cpp
@@ -744,7 +744,7 @@ const FnASTType* Parser::parse_fn_type() {
 
 const ASTType* Parser::parse_return_type(bool& is_continuation, bool mandatory) {
     auto tracker = track();
-    ASTTypes ast_type_args;
+    ASTTypes ast_types;
     is_continuation = false;
     if (accept(Token::ARROW)) {
         if (accept(Token::NOT)) {
@@ -752,23 +752,14 @@ const ASTType* Parser::parse_return_type(bool& is_continuation, bool mandatory) 
             return nullptr;
         }
 
-        if (accept(Token::L_PAREN)) {   // in-place tuple
-            parse_comma_list("closing parenthesis of return type list", Token::R_PAREN, [&] {
-                ast_type_args.emplace_back(parse_type());
-            });
-        } else {
-            auto type = parse_type();
-            assert(!type->isa<TupleASTType>());
-            ast_type_args.emplace_back(type);
-        }
-
-        return new FnASTType(tracker, std::move(ast_type_args));
+        ast_types.emplace_back(parse_type());
+        return new FnASTType(tracker, std::move(ast_types));
     }
 
     if (mandatory) {
         error("return type", "function type");
-        ast_type_args.emplace_back(new ErrorASTType(tracker));
-        return new FnASTType(tracker, std::move(ast_type_args));
+        ast_types.emplace_back(new ErrorASTType(tracker));
+        return new FnASTType(tracker, std::move(ast_types));
     }
 
     return nullptr;

--- a/src/impala/sema/namesema.cpp
+++ b/src/impala/sema/namesema.cpp
@@ -424,6 +424,13 @@ void IdPtrn::bind(NameSema& sema) const {
     local()->bind(sema);
 }
 
+void EnumPtrn::bind(NameSema& sema) const {
+    path()->bind(sema);
+    for (const auto& arg : args()) {
+        arg->bind(sema);
+    }
+}
+
 void LiteralPtrn::bind(NameSema&) const {}
 
 //------------------------------------------------------------------------------

--- a/src/impala/sema/namesema.cpp
+++ b/src/impala/sema/namesema.cpp
@@ -203,7 +203,21 @@ void Typedef::bind(NameSema& sema) const {
     sema.pop_scope();
 }
 
-void EnumDecl::bind(NameSema&) const {}
+void EnumDecl::bind(NameSema& sema) const {
+    sema.push_scope();
+    bind_ast_type_params(sema);
+    for (const auto& option : option_decls()) {
+        option->bind(sema);
+        option_table_[option->symbol()] = option.get();
+    }
+    sema.lambda_depth_ -= num_ast_type_params();
+    sema.pop_scope();
+}
+
+void OptionDecl::bind(NameSema& sema) const {
+    sema.insert(this);
+    for (const auto& arg : args()) arg->bind(sema);
+}
 
 void StaticItem::bind(NameSema& sema) const {
     if (ast_type())
@@ -315,7 +329,7 @@ void PathExpr::bind(NameSema& sema) const {
     }
 }
 
-void PrefixExpr ::bind(NameSema& sema) const {                     rhs()->bind(sema); }
+void PrefixExpr ::bind(NameSema& sema) const {                    rhs()->bind(sema); }
 void InfixExpr  ::bind(NameSema& sema) const { lhs()->bind(sema); rhs()->bind(sema); }
 void PostfixExpr::bind(NameSema& sema) const { lhs()->bind(sema); }
 

--- a/src/impala/sema/type.cpp
+++ b/src/impala/sema/type.cpp
@@ -12,7 +12,9 @@ namespace impala {
 using thorin::streamf;
 
 #define HENK_STRUCT_EXTRA_NAME struct_decl
-#define HENK_STRUCT_EXTRA_TYPE  const StructDecl*
+#define HENK_STRUCT_EXTRA_TYPE const StructDecl*
+#define HENK_ENUM_EXTRA_NAME enum_decl
+#define HENK_ENUM_EXTRA_TYPE const EnumDecl*
 #define HENK_TABLE_TYPE TypeTable
 #define HENK_TABLE_NAME typetable
 #include "thorin/henk.cpp.h"
@@ -188,6 +190,7 @@ std::ostream& DefiniteArrayType::stream(std::ostream& os) const { return streamf
 std::ostream& IndefiniteArrayType::stream(std::ostream& os) const { return streamf(os, "[{}]", elem_type()); }
 std::ostream& SimdType::stream(std::ostream& os) const { return streamf(os, "simd[{} * {}]", elem_type(), dim()); }
 std::ostream& StructType::stream(std::ostream& os) const { return os << struct_decl()->symbol(); }
+std::ostream& EnumType::stream(std::ostream& os) const { return os << enum_decl()->symbol(); }
 
 //std::ostream& TypedefAbsNode::stream(std::ostream& os) const {
     //assert(num_type_params() > 0); // otherwise no TypedefAbsNode should have been used in the first place

--- a/src/impala/sema/type.h
+++ b/src/impala/sema/type.h
@@ -28,6 +28,7 @@ enum Tag {
     Tag_ref,
     Tag_simd,
     Tag_struct,
+    Tag_enum,
     Tag_tuple,
     Tag_typedef_abs,
     Tag_unknown,
@@ -40,6 +41,7 @@ enum PrimTypeTag {
 };
 
 class StructDecl;
+class EnumDecl;
 template<class T> using ArrayRef = thorin::ArrayRef<T>;
 template<class T> using Array    = thorin::Array<T>;
 
@@ -47,12 +49,17 @@ static const int Node_App        = impala::Tag_app;
 static const int Node_Lambda     = impala::Tag_lambda;
 static const int Node_Pi         = impala::Tag_pi;
 static const int Node_StructType = impala::Tag_struct;
+static const int Node_EnumType   = impala::Tag_enum;
 static const int Node_TupleType  = impala::Tag_tuple;
 static const int Node_TypeError  = impala::Tag_error;
 static const int Node_Var        = impala::Tag_var;
 
 #define HENK_STRUCT_EXTRA_NAME  struct_decl
 #define HENK_STRUCT_EXTRA_TYPE  const StructDecl*
+
+#define HENK_ENUM_EXTRA_NAME  enum_decl
+#define HENK_ENUM_EXTRA_TYPE  const EnumDecl*
+
 #define HENK_TABLE_NAME  typetable
 #define HENK_TABLE_TYPE  TypeTable
 #include "thorin/henk.h"

--- a/src/impala/sema/typesema.cpp
+++ b/src/impala/sema/typesema.cpp
@@ -739,6 +739,12 @@ void IdPtrn::check(TypeSema& sema) const {
     sema.check(local());
 }
 
+void EnumPtrn::check(TypeSema& sema) const {
+    for (const auto& arg : args()) {
+        sema.check(arg.get());
+    }
+}
+
 void LiteralPtrn::check(TypeSema& sema) const {
     sema.check(literal());
 }

--- a/src/impala/sema/typesema.cpp
+++ b/src/impala/sema/typesema.cpp
@@ -86,6 +86,7 @@ public:
     const Var* check(const ASTTypeParam* ast_type_param) { ast_type_param->check(*this); return ast_type_param->var(); }
     void check(const Module* module) { module->check(*this); }
     const Type* check(const FieldDecl* n) { n->check(*this); return n->type(); }
+    const Type* check(const OptionDecl* n) { n->check(*this); return n->type(); }
     const Type* check(const LocalDecl* local) { local->check(*this); return local->type(); }
     const Type* check(const ASTType* ast_type) { ast_type->check(*this); return ast_type->type(); }
     void check(const Item* n) { n->check(*this); }
@@ -230,7 +231,15 @@ void Typedef::check(TypeSema& sema) const {
     sema.check(ast_type());
 }
 
-void EnumDecl::check(TypeSema&) const { /*TODO*/ }
+void EnumDecl::check(TypeSema& sema) const {
+    check_ast_type_params(sema);
+    for (const auto& option : option_decls())
+        sema.check(option.get());
+}
+
+void OptionDecl::check(TypeSema& sema) const {
+    for (const auto& arg : args()) sema.check(arg.get());
+}
 
 void StructDecl::check(TypeSema& sema) const {
     check_ast_type_params(sema);

--- a/src/impala/sema/typesema.cpp
+++ b/src/impala/sema/typesema.cpp
@@ -204,16 +204,14 @@ const Type* Fn::check_body(TypeSema& sema) const {
 }
 
 void Path::check(TypeSema&) const {
-    if (decl()) {
-        auto last_type = elem(0)->type();
-        for (size_t i = 1, e = num_elems(); i != e; ++i) {
-            auto cur_type = elem(i)->type();
-            if (cur_type->isa<TypeError>()) {
-                error(this, "'{}' is not a member of '{}'", elem(i)->symbol(), last_type);
-                break;
-            }
-            last_type = cur_type;
+    auto last_type = elem(0)->type();
+    for (size_t i = 1, e = num_elems(); i != e; ++i) {
+        auto cur_type = elem(i)->type();
+        if (cur_type->isa<TypeError>()) {
+            error(this, "'{}' is not a member of '{}'", elem(i)->symbol(), last_type);
+            break;
         }
+        last_type = cur_type;
     }
 }
 

--- a/src/impala/stream.cpp
+++ b/src/impala/stream.cpp
@@ -176,7 +176,11 @@ std::ostream& FieldDecl::stream(std::ostream& os) const {
 
 std::ostream& OptionDecl::stream(std::ostream& os) const {
     streamf(os, "{}", symbol());
-    return stream_list(os, args(), [&](const auto& arg) { os << arg.get(); }, "(", ")", ", ");
+    if (num_args() > 0) {
+        return stream_list(os, args(), [&](const auto& arg) { os << arg.get(); }, "(", ")", ", ");
+    } else {
+        return os;
+    }
 }
 
 std::ostream& StaticItem::stream(std::ostream& os) const {
@@ -494,6 +498,14 @@ std::ostream& TuplePtrn::stream(std::ostream& os) const {
 
 std::ostream& IdPtrn::stream(std::ostream& os) const {
     return os << local();
+}
+
+std::ostream& EnumPtrn::stream(std::ostream& os) const {
+    if (num_args() > 0) {
+        return stream_list(os << path() << "(", args(), [&] (const auto& arg) { os << arg.get(); }) << ")";
+    } else {
+        return os << path();
+    }
 }
 
 std::ostream& LiteralPtrn::stream(std::ostream& os) const {

--- a/src/impala/stream.cpp
+++ b/src/impala/stream.cpp
@@ -174,6 +174,11 @@ std::ostream& FieldDecl::stream(std::ostream& os) const {
     return streamf(os, "{}{}: {}", visibility().str(), symbol(), ast_type());
 }
 
+std::ostream& OptionDecl::stream(std::ostream& os) const {
+    streamf(os, "{}", symbol());
+    return stream_list(os, args(), [&](const auto& arg) { os << arg.get(); }, "(", ")", ", ");
+}
+
 std::ostream& StaticItem::stream(std::ostream& os) const {
     streamf(os, "static {} {}: {}", is_mut() ? "mut " : "", identifier(), type() ? type()->to_string() : ast_type()->to_string());
     if (init())
@@ -184,6 +189,11 @@ std::ostream& StaticItem::stream(std::ostream& os) const {
 std::ostream& StructDecl::stream(std::ostream& os) const {
     stream_ast_type_params(streamf(os, "{}struct {}", visibility().str(), symbol())) << " {" << up << endl;
     return stream_list(os, field_decls(), [&](const auto& field) { os << field.get(); }, "", "", ",", true) << down << endl << "}";
+}
+
+std::ostream& EnumDecl::stream(std::ostream& os) const {
+    stream_ast_type_params(streamf(os, "{}enum {}", visibility().str(), symbol())) << " {" << up << endl;
+    return stream_list(os, option_decls(), [&](const auto& option) { os << option.get(); }, "", "", ",", true) << down << endl << "}";
 }
 
 std::ostream& Typedef::stream(std::ostream& os) const {


### PR DESCRIPTION
This branch allows to use enums. Enums are declared with the keyword `enum`:

```rust
enum Test {
    Foo,
    Bar(i32, f32)
}
```

In order to be used, they must be pattern matched:

```rust
let test = Test::Bar(42, 21.0f);
match test {
    Foo => 55,
    Bar(x, _) => x
    _ => // Mandatory, even if the pattern is irrefutable
}
```

There is however a few things to do before merging:
- [ ] Add a few test cases,
- [X] Improve folding of bitcasts in Thorin,
- [ ] Improve type checker so that enums do not require the extra test `_ => /* ... */` when all cases are handled,
- [ ] Add the `Codegen::bitwidth` function to Thorin.