### PR TITLE
Lazy type propagation for rvalues

### DIFF
--- a/src/impala/ast.cpp
+++ b/src/impala/ast.cpp
@@ -84,6 +84,10 @@ void CastExpr::write() const { src()->write(); }
  * has_side_effect
  */
 
+bool RValueExpr::has_side_effect() const {
+    return src()->has_side_effect();
+}
+
 bool PrefixExpr::has_side_effect() const {
     return tag() == INC || tag() == DEC || tag() == TILDE || tag() == RUN || tag() == HLT;
 }

--- a/src/impala/ast.h
+++ b/src/impala/ast.h
@@ -1507,17 +1507,17 @@ private:
     const Type* infer(InferSema&) const override;
 };
 
-class Ref2ValueExpr : public CastExpr {
+class RValueExpr : public CastExpr {
 public:
-    Ref2ValueExpr(const Expr* src)
+    RValueExpr(const Expr* src)
         : CastExpr(src->location(), src)
-    {
-        type_ = src->type()->as<RefType>()->pointee();
+    {}
+
+    static const RValueExpr* create(const Expr* src) {
+        return interlope<RValueExpr>(src, src);
     }
 
-    static const Ref2ValueExpr* create(const Expr* src) {
-        return interlope<Ref2ValueExpr>(src, src);
-    }
+    bool has_side_effect() const override;
 
     void bind(NameSema&) const override { THORIN_UNREACHABLE; }
     std::ostream& stream(std::ostream&) const override;

--- a/src/impala/sema/typesema.cpp
+++ b/src/impala/sema/typesema.cpp
@@ -500,17 +500,8 @@ void ExplicitCastExpr::check(TypeSema& sema) const {
     CastExpr::check(sema);
 }
 
-void Ref2ValueExpr::check(TypeSema& sema) const {
-    auto src_type = sema.check(src());
-    auto dst_type = type();
-
-    if (auto ref = src_type->isa<RefType>())
-        src_type = ref->pointee();
-    else
-        error(this, "source type of an ref-to-rvalue cast must be an ref, got '{}'", src_type);
-
-    if (src_type->is_known() && dst_type->is_known() && src_type != dst_type)
-        error(this, "invalid source and destination types for ref-to-rvalue cast, got '{}' and '{}'", src_type, dst_type);
+void RValueExpr::check(TypeSema& sema) const {
+    sema.check(src());
 }
 
 void TupleExpr::check(TypeSema& sema) const {

--- a/src/impala/sema/typesema.cpp
+++ b/src/impala/sema/typesema.cpp
@@ -592,8 +592,11 @@ void MapExpr::check(TypeSema& sema) const {
     for (const auto& arg : args())
         sema.check(arg.get());
 
-    if (ltype->isa<FnType>())
+    if (ltype->isa<FnType>()) {
+        if (!type()->is_known())
+            error(this, "cannot infer type for function call");
         return sema.check_call(lhs(), args());
+    }
 
     if (ltype->isa<ArrayType>()) {
         if (num_args() == 1)

--- a/src/impala/stream.cpp
+++ b/src/impala/stream.cpp
@@ -382,9 +382,12 @@ std::ostream& ImplicitCastExpr::stream(std::ostream& os) const {
     return close(os, open_state);
 }
 
-std::ostream& Ref2ValueExpr::stream(std::ostream& os) const {
+std::ostream& RValueExpr::stream(std::ostream& os) const {
     auto open_state = open(os, Prec::As);
-    streamf(os, "ref2value({}, {})", src(), type());
+    if (type())
+        streamf(os, "rvalue({}, {})", src(), type());
+    else
+        streamf(os, "rvalue({}, ?)", src());
     return close(os, open_state);
 }
 


### PR DESCRIPTION
As you may already know, some tests related to rvalues/lvalues are not working (e.g. fieldexpr). This is because we are too eager in our propagation of constraints. Calling `sema.rvalue` does not create a `ref 2rvalue` node if the type of the expression is unknown. Therefore, every user of `sema.rvalue` must check if the types are known beforehand. That's unpractical, so this branch introduces the following changes:

- `Ref2RValueExpr` is now simply `RValueExpr`
- The type inference rules for `RValueExpr` are:
    - `rvalue(?1)` => `?2`
    - `rvalue(T)` => `T` if `T` != `ref U`
    - `rvalue(ref T)` => `T`
- `fieldexpr.impala` and other test cases now pass, except for `bitcast.impala` (see the next point)
- Polymorphic functions whose return types are not bound to the arguments cannot have their return type inferred:
    `let i : int = undef()`
This is because `rvalue(undef())` will not propagate the return type of `undef()`.

A proper fix for the last issue would be to incorporate the subtyping rules into the unification algorithm. Let me know if this should be merged or not.