### PR TITLE
Mem2reg

### DIFF
--- a/src/impala/ast.h
+++ b/src/impala/ast.h
@@ -879,7 +879,7 @@ public:
     const StructType* struct_type() const { return type_->as<StructType>(); }
 
     void bind(NameSema&) const override;
-    void emit(CodeGen&) const override;
+    void emit(CodeGen&) const; 
     std::ostream& stream(std::ostream&) const override;
 
 private:
@@ -906,7 +906,7 @@ public:
     const EnumDecl* enum_decl() const { return enum_decl_; }
 
     void bind(NameSema&) const;
-    const thorin::Def* emit(CodeGen&) const;
+    void emit(CodeGen&) const;
     std::ostream& stream(std::ostream&) const override;
 
     const thorin::Type* variant_type(CodeGen&) const;

--- a/src/impala/ast.h
+++ b/src/impala/ast.h
@@ -715,8 +715,8 @@ public:
 
     Visibility visibility() const { return visibility_; }
     virtual void bind(NameSema&) const = 0;
-    virtual void emit(CodeGen&) const = 0;
     virtual void emit_head(CodeGen&) const {};
+    virtual void emit(CodeGen&) const = 0;
 
 private:
     virtual void infer(InferSema&) const = 0;
@@ -800,7 +800,8 @@ public:
     const FnDecls& fn_decls() const { return fn_decls_; }
 
     void bind(NameSema&) const override;
-    void emit(CodeGen&) const override;
+    void emit_head(CodeGen&) const override;
+    void emit(CodeGen&) const override {}
     std::ostream& stream(std::ostream&) const override;
 
 private:
@@ -879,7 +880,8 @@ public:
     const StructType* struct_type() const { return type_->as<StructType>(); }
 
     void bind(NameSema&) const override;
-    void emit(CodeGen&) const; 
+    void emit_head(CodeGen&) const override;
+    void emit(CodeGen&) const override {}
     std::ostream& stream(std::ostream&) const override;
 
 private:
@@ -944,7 +946,8 @@ public:
     const EnumType* enum_type() const { return type_->as<EnumType>(); }
 
     void bind(NameSema&) const override;
-    void emit(CodeGen&) const override;
+    void emit_head(CodeGen&) const override;
+    void emit(CodeGen&) const override {}
     std::ostream& stream(std::ostream& os) const override;
 
 private:
@@ -968,8 +971,8 @@ public:
     const Expr* init() const { return init_.get(); }
 
     void bind(NameSema&) const override;
-    void emit(CodeGen&) const override {}
     void emit_head(CodeGen&) const override;
+    void emit(CodeGen&) const override {}
     std::ostream& stream(std::ostream&) const override;
 
 private:
@@ -1003,8 +1006,8 @@ public:
     Symbol fn_symbol() const override { return export_name_ != "" ? export_name_ : identifier()->symbol(); }
 
     void bind(NameSema&) const override;
-    void emit_head(CodeGen& cg) const override;
-    void emit(CodeGen& cg) const override;
+    void emit_head(CodeGen&) const override;
+    void emit(CodeGen&) const override;
     std::ostream& stream(std::ostream&) const override;
 
 private:

--- a/src/impala/ast.h
+++ b/src/impala/ast.h
@@ -1311,6 +1311,7 @@ private:
     const Type* infer(InferSema&) const override;
     void check(TypeSema&) const override;
     const thorin::Def* lemit(CodeGen&) const override;
+    const thorin::Def* remit(CodeGen&) const override;
 
     std::unique_ptr<const Path> path_;
 };

--- a/src/impala/ast.h
+++ b/src/impala/ast.h
@@ -1113,8 +1113,6 @@ private:
     virtual void check(TypeSema&) const = 0;
     virtual const thorin::Def* lemit(CodeGen&) const;
     virtual const thorin::Def* remit(CodeGen&) const;
-    virtual void emit_jump(CodeGen&, thorin::Continuation*) const;
-    virtual void emit_branch(CodeGen&, thorin::Continuation*, thorin::Continuation*) const;
 
 protected:
     /// Needed to propagate extend of indefinite arrays.
@@ -1347,7 +1345,6 @@ public:
     void bind(NameSema&) const override;
     const thorin::Def* lemit(CodeGen&) const override;
     const thorin::Def* remit(CodeGen&) const override;
-    void emit_branch(CodeGen&, thorin::Continuation*, thorin::Continuation*) const override;
     std::ostream& stream(std::ostream&) const override;
 
 private:
@@ -1380,7 +1377,6 @@ public:
     bool has_side_effect() const override;
     void bind(NameSema&) const override;
     const thorin::Def* remit(CodeGen&) const override;
-    void emit_branch(CodeGen&, thorin::Continuation*, thorin::Continuation*) const override;
     std::ostream& stream(std::ostream&) const override;
 
 private:
@@ -1790,7 +1786,6 @@ public:
     bool has_side_effect() const override;
     void bind(NameSema&) const override;
     const thorin::Def* remit(CodeGen&) const override;
-    void emit_jump(CodeGen&, thorin::Continuation*) const override;
     std::ostream& stream(std::ostream&) const override;
 
 private:
@@ -1837,7 +1832,6 @@ public:
     bool has_side_effect() const override;
     void bind(NameSema&) const override;
     const thorin::Def* remit(CodeGen&) const override;
-    void emit_jump(CodeGen&, thorin::Continuation*) const override;
     std::ostream& stream(std::ostream&) const override;
 
 private:
@@ -1867,7 +1861,6 @@ public:
     bool has_side_effect() const override;
     void bind(NameSema&) const override;
     const thorin::Def* remit(CodeGen&) const override;
-    void emit_jump(CodeGen&, thorin::Continuation*) const override;
     std::ostream& stream(std::ostream&) const override;
 
 private:

--- a/src/impala/ast.h
+++ b/src/impala/ast.h
@@ -519,17 +519,14 @@ public:
         , written_(false)
         , done_(false)
     {}
-
     /// @p NoDecl.
     Decl(Location location)
         : Decl(NoDecl, location, false, nullptr, nullptr)
     {}
-
     /// @p TypeableDecl, @p TypeDecl or @p ValueDecl.
     Decl(Tag tag, Location location, const Identifier* id)
         : Decl(tag, location, false, id, nullptr)
     {}
-
     /// @p ValueDecl.
     Decl(Location location, bool mut, const Identifier* id, const ASTType* ast_type)
         : Decl(ValueDecl, location, mut, id, ast_type)
@@ -556,6 +553,7 @@ public:
     bool is_written() const { assert(is_value_decl()); return written_; }
     void write() const { assert(is_value_decl()); written_ = true; }
     virtual const thorin::Def* emit(CodeGen&, const thorin::Def*) const { THORIN_UNREACHABLE; }
+    const thorin::Def* def() const { return def_; }
 
 private:
     Tag tag_;
@@ -563,7 +561,7 @@ private:
     std::unique_ptr<const ASTType> ast_type_;
 
 protected:
-    mutable const thorin::Def* value_;
+    mutable const thorin::Def* def_ = nullptr;
     mutable const Decl* shadows_;
     mutable unsigned depth_   : 24;
     unsigned mut_             :  1;

--- a/src/impala/ast.h
+++ b/src/impala/ast.h
@@ -968,7 +968,8 @@ public:
     const Expr* init() const { return init_.get(); }
 
     void bind(NameSema&) const override;
-    void emit(CodeGen&) const override;
+    void emit(CodeGen&) const override {}
+    void emit_head(CodeGen&) const override;
     std::ostream& stream(std::ostream&) const override;
 
 private:

--- a/src/impala/ast.h
+++ b/src/impala/ast.h
@@ -972,7 +972,7 @@ public:
 
     void bind(NameSema&) const override;
     void emit_head(CodeGen&) const override;
-    void emit(CodeGen&) const override {}
+    void emit(CodeGen&) const override;
     std::ostream& stream(std::ostream&) const override;
 
 private:

--- a/src/impala/emit.cpp
+++ b/src/impala/emit.cpp
@@ -873,6 +873,8 @@ const Def* WhileExpr::remit(CodeGen& cg) const {
     cg.cur_bb->jump(head_bb, {cg.cur_mem}, body()->location().back());
 
     cg.enter(exit_bb, mem);
+    cg.cur_bb->jump(brk__bb, {cg.cur_mem}, body()->location().back());
+
     cg.enter(brk__bb, brk__bb->param(0));
     return cg.world.tuple({}, location());
 }

--- a/src/impala/emit.cpp
+++ b/src/impala/emit.cpp
@@ -349,8 +349,12 @@ void ModuleDecl::emit(CodeGen&) const {}
 void ImplItem::emit(CodeGen&) const {}
 
 void StaticItem::emit_head(CodeGen& cg) const {
-    auto i = init() ? init()->remit(cg) : cg.world.bottom(cg.convert(type()), location());
-    def_ = is_mut() ? cg.world.global(i, true, debug()) : i;
+    def_ = cg.world.global(cg.world.bottom(cg.convert(type()), location()));
+}
+
+void StaticItem::emit(CodeGen& cg) const {
+    if (init())
+        def_->replace(cg.world.global(init()->remit(cg), is_mut(), debug()));
 }
 
 void StructDecl::emit_head(CodeGen& cg) const {
@@ -445,7 +449,7 @@ const Def* PathExpr::lemit(CodeGen&) const {
 
 const Def* PathExpr::remit(CodeGen& cg) const {
     auto def = value_decl()->def();
-    return value_decl()->is_mut() ? cg.load(def, location()) : def;
+    return value_decl()->is_mut() || def->isa<Global>() ? cg.load(def, location()) : def;
 }
 
 const Def* PrefixExpr::remit(CodeGen& cg) const {

--- a/src/impala/emit.cpp
+++ b/src/impala/emit.cpp
@@ -833,7 +833,6 @@ const Def* MatchExpr::remit(CodeGen& cg) const {
                 cg.cur_bb->jump(join, {cg.cur_mem, def}, location().back());
         }
     } else {
-        auto mem = cg.cur_mem;
         // general case: if/else
         for (size_t i = 0, e = num_arms(); i != e; ++i) {
             auto case_true  = cg.basicblock({arm(i)->location().front(), "case_true"});
@@ -848,6 +847,7 @@ const Def* MatchExpr::remit(CodeGen& cg) const {
 
             cg.cur_bb->branch(cond, case_true, case_false, arm(i)->ptrn()->location().back());
 
+            auto mem = cg.cur_mem;
             cg.enter(case_true, mem);
             if (auto def = arm(i)->expr()->remit(cg))
                 cg.cur_bb->jump(join, {cg.cur_mem, def}, arm(i)->location().back());

--- a/src/impala/emit.cpp
+++ b/src/impala/emit.cpp
@@ -743,13 +743,13 @@ const Def* IfExpr::remit(CodeGen& cg) const {
 
     auto c = cond()->remit(cg);
     cg.cur_bb->branch(c, if_then, if_else, cond()->location().back());
-    auto mem = cg.cur_mem;
+    auto head_mem = cg.cur_mem;
 
-    cg.enter(if_then, mem);
+    cg.enter(if_then, head_mem);
     if (auto tdef = then_expr()->remit(cg))
         cg.cur_bb->jump(if_join, {cg.cur_mem, tdef}, location().back());
 
-    cg.enter(if_else, mem);
+    cg.enter(if_else, head_mem);
     if (auto fdef = else_expr()->remit(cg))
         cg.cur_bb->jump(if_join, {cg.cur_mem, fdef}, location().back());
 
@@ -853,18 +853,18 @@ const Def* WhileExpr::remit(CodeGen& cg) const {
     cg.cur_bb->jump(head_bb, {cg.cur_mem}, cond()->location().back());
 
     cg.enter(head_bb, head_bb->param(0));
-    auto mem = cg.cur_mem;
     auto c = cond()->remit(cg);
     cg.cur_bb->branch(c, body_bb, exit_bb);
+    auto head_mem = cg.cur_mem;
 
-    cg.enter(body_bb, mem);
+    cg.enter(body_bb, cg.cur_mem);
     body()->remit(cg);
     cg.cur_bb->jump(cont_bb, {cg.cur_mem}, body()->location().back());
 
     cg.enter(cont_bb, cont_bb->param(0));
     cg.cur_bb->jump(head_bb, {cg.cur_mem}, body()->location().back());
 
-    cg.enter(exit_bb, mem);
+    cg.enter(exit_bb, head_mem);
     cg.cur_bb->jump(brk__bb, {cg.cur_mem}, body()->location().back());
 
     cg.enter(brk__bb, brk__bb->param(0));

--- a/src/impala/emit.cpp
+++ b/src/impala/emit.cpp
@@ -28,7 +28,7 @@ public:
 
     //void emit_jump_boolean(bool val, Continuation* x, const thorin::Location& loc) {
         //if (is_reachable()) {
-            //cur_bb->set_value(1, world().literal(val, loc));
+            //cur_bb->set_value(1, world.literal(val, loc));
             //jump(x, loc);
         //}
     //}
@@ -42,20 +42,37 @@ public:
 
     void set_continuation(Continuation* continuation) {
         cur_bb = continuation;
-        set_mem(continuation->param(0));
+        cur_mem = continuation->param(0);
     }
 
     void jump_to_continuation(Continuation* continuation, const thorin::Location& loc) {
-        if (is_reachable())
-            cur_bb->jump(continuation, {get_mem()}, loc);
+        cur_bb->jump(continuation, {cur_mem}, loc);
         set_continuation(continuation);
+    }
+
+    const Def* load(const Def* ptr, Location location) {
+        auto l = world.load(cur_mem, ptr, location);
+        cur_mem = world.extract(l, 0_s, location);
+        return world.extract(l, 1_s, location);
+    }
+
+    void store(const Def* ptr, const Def* val, Location location) {
+        cur_mem = world.store(cur_mem, ptr, val, location);
+    }
+
+    const Def* alloc(const thorin::Type* type, const Def* extra, Debug dbg) {
+        if (!extra)
+            extra = world.literal_qu64(0, dbg);
+        auto alloc = world.alloc(type, cur_mem, extra, dbg);
+        cur_mem = world.extract(alloc, 0_s, dbg);
+        return world.extract(alloc, 1, dbg);
     }
 
     const Def* lemit(const Expr* expr) { return expr->lemit(*this); }
     const Def* remit(const Expr* expr) { return expr->remit(*this); }
-    void emit_jump(const Expr* expr, Continuation* x) { if (is_reachable()) expr->emit_jump(*this, x); }
+    void emit_jump(const Expr* expr, Continuation* x) { expr->emit_jump(*this, x); }
     void emit_branch(const Expr* expr, Continuation* t, Continuation* f) { expr->emit_branch(*this, t, f); }
-    void emit(const Stmt* stmt) { if (is_reachable()) stmt->emit(*this); }
+    void emit(const Stmt* stmt) { stmt->emit(*this); }
     void emit(const Item* item) {
         assert(!item->done_);
         item->emit(*this);
@@ -65,7 +82,6 @@ public:
     }
     void emit(const Ptrn* ptrn, const thorin::Def* def) { ptrn->emit(*this, def); }
     const Def* emit(const Decl* decl) {
-        assert(decl->value_.tag() != thorin::Value::Empty);
         return decl->value_;
     }
     const Def* emit(const Decl* decl, const Def* init) {
@@ -102,29 +118,29 @@ public:
 
 const thorin::Type* CodeGen::convert_rec(const Type* type) {
     if (auto lambda = type->isa<Lambda>()) {
-        return world().lambda(convert(lambda->body()), lambda->name());
+        return world.lambda(convert(lambda->body()), lambda->name());
     } else if (auto var = type->isa<Var>()) {
-        return world().var(var->depth());
+        return world.var(var->depth());
     } else if (auto prim_type = type->isa<PrimType>()) {
         switch (prim_type->primtype_tag()) {
 #define IMPALA_TYPE(itype, ttype) \
-            case PrimType_##itype: return world().type_##ttype();
+            case PrimType_##itype: return world.type_##ttype();
 #include "impala/tokenlist.h"
             default: THORIN_UNREACHABLE;
         }
     } else if (auto fn_type = type->isa<FnType>()) {
         std::vector<const thorin::Type*> nops;
-        nops.push_back(world().mem_type());
+        nops.push_back(world.mem_type());
         for (size_t i = 0, e = fn_type->num_params(); i != e; ++i)
             nops.push_back(convert(fn_type->param(i)));
-        return world().fn_type(nops);
+        return world.fn_type(nops);
     } else if (auto tuple_type = type->isa<TupleType>()) {
         std::vector<const thorin::Type*> nops;
         for (const auto& op : tuple_type->ops())
             nops.push_back(convert(op));
-        return world().tuple_type(nops);
+        return world.tuple_type(nops);
     } else if (auto struct_type = type->isa<StructType>()) {
-        auto s = world().struct_type(struct_type->struct_decl()->symbol(), struct_type->num_ops());
+        auto s = world.struct_type(struct_type->struct_decl()->symbol(), struct_type->num_ops());
         thorin_struct_type(struct_type) = s;
         thorin_type(type) = s;
         size_t i = 0;
@@ -133,7 +149,7 @@ const thorin::Type* CodeGen::convert_rec(const Type* type) {
         thorin_type(type) = nullptr; // will be set again by CodeGen's wrapper
         return s;
     } else if (auto enum_type = type->isa<EnumType>()) {
-        auto s = world().struct_type(enum_type->enum_decl()->symbol(), 2);
+        auto s = world.struct_type(enum_type->enum_decl()->symbol(), 2);
         thorin_enum_type(enum_type) = s;
         thorin_type(enum_type) = s;
 
@@ -144,18 +160,18 @@ const thorin::Type* CodeGen::convert_rec(const Type* type) {
         thorin::Array<const thorin::Type*> ops(variants.size());
         std::copy(variants.begin(), variants.end(), ops.begin());
 
-        s->set(0, world().type_qu32());
-        s->set(1, world().variant_type(ops));
+        s->set(0, world.type_qu32());
+        s->set(1, world.variant_type(ops));
         thorin_type(enum_type) = nullptr;
         return s;
     } else if (auto ptr_type = type->isa<PtrType>()) {
-        return world().ptr_type(convert(ptr_type->pointee()), 1, -1, thorin::AddrSpace(ptr_type->addr_space()));
+        return world.ptr_type(convert(ptr_type->pointee()), 1, -1, thorin::AddrSpace(ptr_type->addr_space()));
     } else if (auto definite_array_type = type->isa<DefiniteArrayType>()) {
-        return world().definite_array_type(convert(definite_array_type->elem_type()), definite_array_type->dim());
+        return world.definite_array_type(convert(definite_array_type->elem_type()), definite_array_type->dim());
     } else if (auto indefinite_array_type = type->isa<IndefiniteArrayType>()) {
-        return world().indefinite_array_type(convert(indefinite_array_type->elem_type()));
+        return world.indefinite_array_type(convert(indefinite_array_type->elem_type()));
     } else if (auto simd_type = type->isa<SimdType>()) {
-        return world().type(convert(simd_type->elem_type())->as<thorin::PrimType>()->primtype_tag(), simd_type->dim());
+        return world.type(convert(simd_type->elem_type())->as<thorin::PrimType>()->primtype_tag(), simd_type->dim());
     }
     THORIN_UNREACHABLE;
 }
@@ -166,20 +182,14 @@ const thorin::Type* CodeGen::convert_rec(const Type* type) {
 
 const Def* LocalDecl::emit(CodeGen& cg, const Def* init) const {
     auto thorin_type = cg.convert(type());
+    init = init ? init : cg.world.bottom(thorin_type);
 
-    auto do_init = [&]() {
-        if (init)
-            value_.store(init, location());
-    };
-
-    if (is_address_taken()) {
-        value_ = Value::create_ptr(cg, cg.world().slot(thorin_type, cg.frame(), debug()));
-        do_init();
-    } else if (is_mut()) {
-        value_ = Value::create_mut(cg, handle(), thorin_type);
-        do_init();
-    } else
-        value_ = Value::create_val(cg, init);
+    if (is_mut()) {
+        value_ = cg.world.slot(thorin_type, cg.frame(), debug());
+        cg.cur_mem = cg.world.store(cg.cur_mem, value_, init, debug());
+    } else {
+        value_ = init;
+    }
 
     return value_;
 }
@@ -189,27 +199,27 @@ const thorin::Type* OptionDecl::variant_type(CodeGen& cg) const {
     for (const auto& arg : args())
         types.push_back(cg.convert(arg->type()));
     if (num_args() == 1) return types.back();
-    return cg.world().tuple_type(types);
+    return cg.world.tuple_type(types);
 }
 
 Continuation* Fn::emit_head(CodeGen& cg, Location location) const {
-    return continuation_ = cg.continuation(cg.convert(fn_type())->as<thorin::FnType>(),
-                                           {location, fn_symbol().remove_quotation()});
+    auto t = cg.convert(fn_type())->as<thorin::FnType>();
+    return continuation_ = cg.world.continuation(t, {location, fn_symbol().remove_quotation()});
 }
 
 void Fn::emit_body(CodeGen& cg, Location location) const {
     // setup function nest
-    continuation()->set_parent(cg.cur_bb);
     THORIN_PUSH(cg.cur_fn, this);
     THORIN_PUSH(cg.cur_bb, continuation());
 
     // setup memory + frame
     {
         size_t i = 0;
-        const Def* mem_param = continuation()->param(i++);
+        auto mem_param = continuation()->param(i++);
         mem_param->debug().set("mem");
-        cg.set_mem(mem_param);
-        frame_ = cg.create_frame(location);
+        auto enter = cg.world.enter(mem_param, location);
+        cg.cur_mem = cg.world.extract(enter, 0_s, location);
+        frame_ =     cg.world.extract(enter, 1_s, location);
 
         // name params and setup store locations
         for (const auto& param : params()) {
@@ -228,29 +238,28 @@ void Fn::emit_body(CodeGen& cg, Location location) const {
     // descend into body
     auto def = cg.remit(body());
     if (def) {
-        const Def* mem = cg.get_mem();
         // flatten returned values
         if (auto tuple = body()->type()->isa<TupleType>()) {
             Array<const Def*> ret_values(tuple->num_ops() + 1);
             for (size_t i = 0, e = tuple->num_ops(); i != e; ++i)
-                ret_values[i + 1] = cg.world().extract(def, i);
-            ret_values[0] = mem;
+                ret_values[i + 1] = cg.world.extract(def, i);
+            ret_values[0] = cg.cur_mem;
             cg.cur_bb->jump(ret_param(), ret_values, location.back());
         } else
-            cg.cur_bb->jump(ret_param(), {mem, def}, location.back());
+            cg.cur_bb->jump(ret_param(), {cg.cur_mem, def}, location.back());
     }
 
     // now handle the filter
     {
         size_t i = 0;
-        auto global = pe_expr() ? cg.remit(pe_expr()) : cg.world().literal_bool(false, location);
+        auto global = pe_expr() ? cg.remit(pe_expr()) : cg.world.literal_bool(false, location);
         Array<const Def*> filter(continuation()->num_params());
         filter[i++] = global; // mem param
 
         for (const auto& param : params()) {
             auto pe_expr = param->pe_expr();
             filter[i++] = pe_expr
-                          ? cg.world().arithop_or(global, cg.remit(pe_expr), pe_expr->location())
+                          ? cg.world.arithop_or(global, cg.remit(pe_expr), pe_expr->location())
                           : global;
         }
 
@@ -291,14 +300,13 @@ const Def* FnDecl::emit(CodeGen& cg, const Def*) const {
         return value_;
 
     // create thorin function
-    value_ = Value::create_val(cg, emit_head(cg, location()));
+    value_ = emit_head(cg, location());
     if (is_extern() && abi() == "")
         continuation_->make_external();
 
     // handle main function
-    if (symbol() == "main") {
+    if (symbol() == "main")
         continuation()->make_external();
-    }
 
     if (body())
         emit_body(cg, location());
@@ -334,37 +342,37 @@ void ImplItem::emit(CodeGen& cg) const {
     for (size_t i = 0, e = args.size(); i != e; ++i)
         method(i)->emit_body(cg, location());
 
-    def_ = cg.world().tuple(args, location());
+    def_ = cg.world.tuple(args, location());
 }
 
 const Def* OptionDecl::emit(CodeGen& cg, const Def* init) const {
     assert(!init);
     auto enum_type = enum_decl()->type()->as<EnumType>();
     auto variant_type = cg.convert(enum_type)->op(1)->as<VariantType>();
-    auto id = cg.world().literal_qu32(index(), location());
+    auto id = cg.world.literal_qu32(index(), location());
     if (num_args() == 0) {
-        auto bot = cg.world().bottom(variant_type);
-        return Value::create_val(cg, cg.world().struct_agg(cg.thorin_enum_type(enum_type), { id, bot }) );
+        auto bot = cg.world.bottom(variant_type);
+        return cg.world.struct_agg(cg.thorin_enum_type(enum_type), { id, bot });
     } else {
-        auto continuation = cg.world().continuation(cg.convert(type())->as<thorin::FnType>(), {location(), symbol()});
+        auto continuation = cg.world.continuation(cg.convert(type())->as<thorin::FnType>(), {location(), symbol()});
         auto ret = continuation->param(continuation->num_params() - 1);
         auto mem = continuation->param(0);
         Array<const Def*> defs(num_args());
         for (size_t i = 1, e = continuation->num_params(); i + 1 < e; i++)
             defs[i-1] = continuation->param(i);
-        auto option_val = num_args() == 1 ? defs.back() : cg.world().tuple(defs);
-        auto enum_val = cg.world().struct_agg(cg.thorin_enum_type(enum_type), { id, cg.world().variant(variant_type, option_val) });
+        auto option_val = num_args() == 1 ? defs.back() : cg.world.tuple(defs);
+        auto enum_val = cg.world.struct_agg(cg.thorin_enum_type(enum_type), { id, cg.world.variant(variant_type, option_val) });
         continuation->jump(ret, { mem, enum_val }, location());
-        return Value::create_val(cg, continuation);
+        return continuation;
     }
 }
 
 const Def* StaticItem::emit(CodeGen& cg, const Def* init) const {
     assert(!init);
-    init = !this->init() ? cg.world().bottom(cg.convert(type()), location()) : cg.remit(this->init());
+    init = !this->init() ? cg.world.bottom(cg.convert(type()), location()) : cg.remit(this->init());
     if (!is_mut())
-        return Value::create_val(cg, init);
-    return Value::create_ptr(cg, cg.world().global(init, true, debug()));
+        return init;
+    return cg.world.global(init, true, debug());
 }
 
 void StructDecl::emit(CodeGen& cg) const {
@@ -383,17 +391,24 @@ void Typedef::emit(CodeGen&) const {}
  */
 
 const Def* Expr::lemit(CodeGen&) const { THORIN_UNREACHABLE; }
-const Def* Expr::remit(CodeGen& cg) const { return lemit(cg).load(location()); }
+
+const Def* Expr::remit(CodeGen& cg) const { return cg.load(lemit(cg), location()); }
+
+#if 0
 void Expr::emit_jump(CodeGen& cg, Continuation* x) const {
     if (auto def = cg.remit(this)) {
-        assert(cg.is_reachable());
         cg.cur_bb->set_value(1, def);
         cg.jump(x, location().back());
     } else
         assert(!cg.is_reachable());
 }
-void Expr::emit_branch(CodeGen& cg, Continuation* t, Continuation* f) const { cg.branch(cg.remit(this), t, f, location().back()); }
-const Def* EmptyExpr::remit(CodeGen& cg) const { return cg.world().tuple({}, location()); }
+#endif
+
+void Expr::emit_branch(CodeGen& cg, Continuation* t, Continuation* f) const {
+    cg.cur_bb->branch(cg.remit(this), t, f, location().back());
+}
+
+const Def* EmptyExpr::remit(CodeGen& cg) const { return cg.world.tuple({}, location()); }
 
 const Def* LiteralExpr::remit(CodeGen& cg) const {
     thorin::PrimTypeTag ttag;
@@ -406,25 +421,25 @@ const Def* LiteralExpr::remit(CodeGen& cg) const {
         default: THORIN_UNREACHABLE;
     }
 
-    return cg.world().literal(ttag, box(), location());
+    return cg.world.literal(ttag, box(), location());
 }
 
 const Def* CharExpr::remit(CodeGen& cg) const {
-    return cg.world().literal_pu8(value(), location());
+    return cg.world.literal_pu8(value(), location());
 }
 
 const Def* StrExpr::remit(CodeGen& cg) const {
     Array<const Def*> args(values_.size());
     for (size_t i = 0, e = args.size(); i != e; ++i)
-        args[i] = cg.world().literal_pu8(values_[i], location());
+        args[i] = cg.world.literal_pu8(values_[i], location());
 
-    return cg.world().definite_array(args, location());
+    return cg.world.definite_array(args, location());
 }
 
 const Def* CastExpr::remit(CodeGen& cg) const {
     auto def = cg.remit(src());
     auto thorin_type = cg.convert(type());
-    return cg.world().convert(thorin_type, def, location());
+    return cg.world.convert(thorin_type, def, location());
 }
 
 const Def* RValueExpr::lemit(CodeGen& cg) const {
@@ -432,11 +447,13 @@ const Def* RValueExpr::lemit(CodeGen& cg) const {
     return cg.lemit(src());
 }
 
+#if 0
 const Def* RValueExpr::remit(CodeGen& cg) const {
     if (src()->type()->isa<RefType>())
         return cg.lemit(this).load(location());
     return cg.remit(src());
 }
+#endif
 
 const Def* PathExpr::lemit(CodeGen& cg) const {
     return cg.emit(value_decl(), nullptr);
@@ -447,15 +464,15 @@ const Def* PrefixExpr::remit(CodeGen& cg) const {
         case INC:
         case DEC: {
             auto var = cg.lemit(rhs());
-            const Def* def = var.load(location());
-            const Def* one = cg.world().one(def->type(), location());
-            const Def* ndef = cg.world().arithop(Token::to_arithop((TokenTag) tag()), def, one, location());
-            var.store(ndef, location());
-            return ndef;
+            auto val = cg.load(var, location());
+            auto one = cg.world.one(val->type(), location());
+            val = cg.world.arithop(Token::to_arithop((TokenTag) tag()), val, one, location());
+            cg.store(var, val, location());
+            return val;
         }
         case ADD: return cg.remit(rhs());
-        case SUB: return cg.world().arithop_minus(cg.remit(rhs()), location());
-        case NOT: return cg.world().arithop_not(cg.remit(rhs()), location());
+        case SUB: return cg.world.arithop_minus(cg.remit(rhs()), location());
+        case NOT: return cg.world.arithop_not(cg.remit(rhs()), location());
         case TILDE: {
             auto def = cg.remit(rhs());
             auto ptr = cg.alloc(def->type(), rhs()->extra(), location());
@@ -463,75 +480,70 @@ const Def* PrefixExpr::remit(CodeGen& cg) const {
             return ptr;
         }
         case AND: {
-            if (rhs()->type()->isa<RefType>()) {
-                auto var = cg.lemit(rhs());
-                assert(var.tag() == Value::PtrRef);
-                return var.def();
-            }
+            if (rhs()->type()->isa<RefType>())
+                return cg.lemit(rhs());
 
             auto def = cg.remit(rhs());
             if (is_const(def))
-                return cg.world().global(def, /*mutable*/ false, location());
+                return cg.world.global(def, /*mutable*/ false, location());
 
-            auto slot = cg.world().slot(cg.convert(rhs()->type()), cg.frame(), location());
+            auto slot = cg.world.slot(cg.convert(rhs()->type()), cg.frame(), location());
             cg.store(slot, def, location());
             return slot;
         }
         case MUT: {
-            auto var = cg.lemit(rhs());
-            assert(var.tag() == Value::PtrRef);
-            return var.def();
+            return cg.lemit(rhs());
         }
         case RUNRUN: {
             auto def = cg.remit(rhs()->skip_rvalue());
-            return cg.world().run(def, location());
+            return cg.world.run(def, location());
         }
         case HLT: {
             auto def = cg.remit(rhs()->skip_rvalue());
-            return cg.world().hlt(def, location());
+            return cg.world.hlt(def, location());
         }
         case KNOWN: {
             auto def = cg.remit(rhs()->skip_rvalue());
-            return cg.world().known(def, location());
+            return cg.world.known(def, location());
         }
         case OR:
         case OROR:
             THORIN_UNREACHABLE;
-        default:  return cg.lemit(this).load(location());
+        default:
+            return cg.load(cg.lemit(this), location());
     }
 }
 
 const Def* PrefixExpr::lemit(CodeGen& cg) const {
-    if (tag() == MUL)
-        return Value::create_ptr(cg, cg.remit(rhs()));
-    THORIN_UNREACHABLE; // TODO
+    assert(tag() == MUL);
+    return cg.remit(rhs());
 }
 
 void PrefixExpr::emit_branch(CodeGen& cg, Continuation* t, Continuation* f) const {
     if (tag() == NOT && is_type_bool(cg.convert(type())))
         cg.emit_branch(rhs(), f, t);
     else
-        cg.branch(cg.remit(this), t, f, location().back());
+        cg.cur_bb->branch(cg.remit(this), t, f, location().back());
 }
 
 void InfixExpr::emit_branch(CodeGen& cg, Continuation* t, Continuation* f) const {
     switch (tag()) {
         case ANDAND: {
-            auto x = cg.world().basicblock({rhs()->location().front(), "and_extra"});
+            auto x = cg.world.basicblock({rhs()->location().front(), "and_extra"});
             cg.emit_branch(lhs(), x, f);
-            if (cg.enter(x))
-                cg.emit_branch(rhs(), t, f);
+            cg.cur_bb = x;
+            cg.emit_branch(rhs(), t, f);
             return;
         }
         case OROR: {
-            auto x = cg.world().basicblock({rhs()->location().front(), "or_extra"});
+            auto x = cg.world.basicblock({rhs()->location().front(), "or_extra"});
             cg.emit_branch(lhs(), t, x);
-            if (cg.enter(x))
-                cg.emit_branch(rhs(), t, f);
+            cg.cur_bb = x;
+            cg.emit_branch(rhs(), t, f);
             return;
         }
         default:
-            cg.branch(cg.remit(this), t, f, location().back());
+            cg.cur_bb->branch(cg.remit(this), t, f, location().back());
             return;
     }
 }
@@ -539,50 +551,56 @@ void InfixExpr::emit_branch(CodeGen& cg, Continuation* t, Continuation* f) const
 const Def* InfixExpr::remit(CodeGen& cg) const {
     switch (tag()) {
         case ANDAND: {
-            JumpTarget t({lhs()->location().front(), "and_true"});
-            JumpTarget f({rhs()->location().front(), "and_false"});
-            JumpTarget x({location().back(), "and_exit"});
+            auto t = cg.world.basicblock({lhs()->location().front(), "and_true"});
+            auto f = cg.world.basicblock({rhs()->location().front(), "and_false"});
+            auto x = cg.world.basicblock({location().back(), "and_exit"});
             cg.emit_branch(lhs(), t, f);
-            if (cg.enter(t)) cg.emit_jump(rhs(), x);
-            if (cg.enter(f)) cg.emit_jump_boolean(false, x, lhs()->location().back());
-            return cg.converge(this, x);
+            cg.cur_bb = t;
+            cg.emit_jump(rhs(), x);
+            cg.cur_bb = f;
+            // TODO
+            //cg.emit_jump_boolean(false, x, lhs()->location().back());
+            //return cg.converge(this, x);
         }
         case OROR: {
-            JumpTarget t({lhs()->location().front(), "or_true"});
-            JumpTarget f({rhs()->location().front(), "or_false"});
-            JumpTarget x({location().back(), "or_exit"});
+            auto t = cg.world.basicblock({lhs()->location().front(), "or_true"});
+            auto f = cg.world.basicblock({rhs()->location().front(), "or_false"});
+            auto x = cg.world.basicblock({location().back(), "or_exit"});
             cg.emit_branch(lhs(), t, f);
-            if (cg.enter(t)) cg.emit_jump_boolean(true, x, rhs()->location().back());
-            if (cg.enter(f)) cg.emit_jump(rhs(), x);
-            return cg.converge(this, x);
+            cg.cur_bb = t;
+            // TODO
+            //cg.emit_jump_boolean(true, x, rhs()->location().back());
+            cg.cur_bb = f;
+            cg.emit_jump(rhs(), x);
+            //return cg.converge(this, x);
         }
         default:
             const TokenTag op = (TokenTag) tag();
 
             if (Token::is_assign(op)) {
-                Value lvar = cg.lemit(lhs());
-                const Def* rdef = cg.remit(rhs());
+                auto lvar = cg.lemit(lhs());
+                auto rdef = cg.remit(rhs());
 
                 if (op != Token::ASGN) {
-                    TokenTag sop = Token::separate_assign(op);
-                    rdef = cg.world().binop(Token::to_binop(sop), lvar.load(location()), rdef, location());
+                    auto sop = Token::separate_assign(op);
+                    rdef = cg.world.binop(Token::to_binop(sop), cg.load(lvar, location()), rdef, location());
                 }
 
-                lvar.store(rdef, location());
-                return cg.world().tuple({}, location());
+                cg.store(lvar, rdef, location());
+                return cg.world.tuple({}, location());
             }
 
-            const Def* ldef = cg.remit(lhs());
-            const Def* rdef = cg.remit(rhs());
-            return cg.world().binop(Token::to_binop(op), ldef, rdef, location());
+            auto ldef = cg.remit(lhs());
+            auto rdef = cg.remit(rhs());
+            return cg.world.binop(Token::to_binop(op), ldef, rdef, location());
     }
 }
 
 const Def* PostfixExpr::remit(CodeGen& cg) const {
-    Value var = cg.lemit(lhs());
-    const Def* def = var.load(location());
-    const Def* one = cg.world().one(def->type(), location());
-    var.store(cg.world().arithop(Token::to_arithop((TokenTag) tag()), def, one, location()), location());
+    auto var = cg.lemit(lhs());
+    auto def = cg.load(var, location());
+    auto one = cg.world.one(def->type(), location());
+    cg.store(var, cg.world.arithop(Token::to_arithop((TokenTag) tag()), def, one, location()), location());
     return def;
 }
 
@@ -590,39 +608,39 @@ const Def* DefiniteArrayExpr::remit(CodeGen& cg) const {
     Array<const Def*> thorin_args(num_args());
     for (size_t i = 0, e = num_args(); i != e; ++i)
         thorin_args[i] = cg.remit(arg(i));
-    return cg.world().definite_array(cg.convert(type())->as<thorin::DefiniteArrayType>()->elem_type(), thorin_args, location());
+    return cg.world.definite_array(cg.convert(type())->as<thorin::DefiniteArrayType>()->elem_type(), thorin_args, location());
 }
 
 const Def* RepeatedDefiniteArrayExpr::remit(CodeGen& cg) const {
     Array<const Def*> args(count());
     std::fill_n(args.begin(), count(), cg.remit(value()));
-    return cg.world().definite_array(args, location());
+    return cg.world.definite_array(args, location());
 }
 
 const Def* TupleExpr::remit(CodeGen& cg) const {
     Array<const Def*> thorin_args(num_args());
     for (size_t i = 0, e = num_args(); i != e; ++i)
         thorin_args[i] = cg.remit(arg(i));
-    return cg.world().tuple(thorin_args, location());
+    return cg.world.tuple(thorin_args, location());
 }
 
 const Def* IndefiniteArrayExpr::remit(CodeGen& cg) const {
     extra_ = cg.remit(dim());
-    return cg.world().indefinite_array(cg.convert(type())->as<thorin::IndefiniteArrayType>()->elem_type(), extra_, location());
+    return cg.world.indefinite_array(cg.convert(type())->as<thorin::IndefiniteArrayType>()->elem_type(), extra_, location());
 }
 
 const Def* SimdExpr::remit(CodeGen& cg) const {
     Array<const Def*> thorin_args(num_args());
     for (size_t i = 0, e = num_args(); i != e; ++i)
         thorin_args[i] = cg.remit(arg(i));
-    return cg.world().vector(thorin_args, location());
+    return cg.world.vector(thorin_args, location());
 }
 
 const Def* StructExpr::remit(CodeGen& cg) const {
     Array<const Def*> defs(num_elems());
     for (const auto& elem : elems())
         defs[elem->field_decl()->index()] = cg.remit(elem->expr());
-    return cg.world().struct_agg(cg.convert(type())->as<thorin::StructType>(), defs, location());
+    return cg.world.struct_agg(cg.convert(type())->as<thorin::StructType>(), defs, location());
 }
 
 const Def* TypeAppExpr::lemit(CodeGen&) const { THORIN_UNREACHABLE; }
@@ -634,7 +652,7 @@ const Def* TypeAppExpr::remit(CodeGen& /*cg*/) const {
 
 const Def* MapExpr::lemit(CodeGen& cg) const {
     auto agg = cg.lemit(lhs());
-    return Value::create_agg(agg, cg.remit(arg(0)));
+    return cg.world.lea(agg, cg.remit(arg(0)), location());
 }
 
 const Def* MapExpr::remit(CodeGen& cg) const {
@@ -651,57 +669,57 @@ const Def* MapExpr::remit(CodeGen& cg) const {
                     if (fn_decl->is_extern() && fn_decl->abi() == "\"thorin\"") {
                         auto name = fn_decl->fn_symbol().remove_quotation();
                         if (name == "bitcast") {
-                            return cg.world().bitcast(cg.convert(type_expr->type_arg(0)), cg.remit(arg(0)), location());
+                            return cg.world.bitcast(cg.convert(type_expr->type_arg(0)), cg.remit(arg(0)), location());
                         } else if (name == "select") {
-                            return cg.world().select(cg.remit(arg(0)), cg.remit(arg(1)), cg.remit(arg(2)), location());
+                            return cg.world.select(cg.remit(arg(0)), cg.remit(arg(1)), cg.remit(arg(2)), location());
                         } else if (name == "insert") {
-                            return cg.world().insert(cg.remit(arg(0)), cg.remit(arg(1)), cg.remit(arg(2)), location());
+                            return cg.world.insert(cg.remit(arg(0)), cg.remit(arg(1)), cg.remit(arg(2)), location());
                         } else if (name == "sizeof") {
-                            return cg.world().size_of(cg.convert(type_expr->type_arg(0)), location());
+                            return cg.world.size_of(cg.convert(type_expr->type_arg(0)), location());
                         } else if (name == "undef") {
-                            return cg.world().bottom(cg.convert(type_expr->type_arg(0)), location());
+                            return cg.world.bottom(cg.convert(type_expr->type_arg(0)), location());
                         } else if (name == "reserve_shared") {
                             auto ptr_type = cg.convert(type());
-                            auto fn_type = cg.world().fn_type({
-                                cg.world().mem_type(), cg.world().type_qs32(),
-                                cg.world().fn_type({ cg.world().mem_type(), ptr_type }) });
-                            auto cont = cg.world().continuation(fn_type, {location(), "reserve_shared"});
+                            auto fn_type = cg.world.fn_type({
+                                cg.world.mem_type(), cg.world.type_qs32(),
+                                cg.world.fn_type({ cg.world.mem_type(), ptr_type }) });
+                            auto cont = cg.world.continuation(fn_type, {location(), "reserve_shared"});
                             cont->set_intrinsic();
                             dst = cont;
                         } else if (name == "atomic") {
                             auto poly_type = cg.convert(type());
                             auto ptr_type = cg.convert(arg(1)->type());
-                            auto fn_type = cg.world().fn_type({
-                                cg.world().mem_type(), cg.world().type_pu32(), ptr_type, poly_type,
-                                cg.world().fn_type({ cg.world().mem_type(), poly_type }) });
-                            auto cont = cg.world().continuation(fn_type, {location(), "atomic"});
+                            auto fn_type = cg.world.fn_type({
+                                cg.world.mem_type(), cg.world.type_pu32(), ptr_type, poly_type,
+                                cg.world.fn_type({ cg.world.mem_type(), poly_type }) });
+                            auto cont = cg.world.continuation(fn_type, {location(), "atomic"});
                             cont->set_intrinsic();
                             dst = cont;
                         } else if (name == "cmpxchg") {
                             auto ptr_type = cg.convert(arg(0)->type());
                             auto poly_type = ptr_type->as<thorin::PtrType>()->pointee();
-                            auto fn_type = cg.world().fn_type({
-                                cg.world().mem_type(), ptr_type, poly_type, poly_type,
-                                cg.world().fn_type({ cg.world().mem_type(), poly_type, cg.world().type_bool() })
+                            auto fn_type = cg.world.fn_type({
+                                cg.world.mem_type(), ptr_type, poly_type, poly_type,
+                                cg.world.fn_type({ cg.world.mem_type(), poly_type, cg.world.type_bool() })
                             });
-                            auto cont = cg.world().continuation(fn_type, {location(), "cmpxchg"});
+                            auto cont = cg.world.continuation(fn_type, {location(), "cmpxchg"});
                             cont->set_intrinsic();
                             dst = cont;
                         } else if (name == "pe_info") {
                             auto poly_type = cg.convert(arg(1)->type());
-                            auto string_type = cg.world().ptr_type(cg.world().indefinite_array_type(cg.world().type_pu8()));
-                            auto fn_type = cg.world().fn_type({
-                                cg.world().mem_type(), string_type, poly_type,
-                                cg.world().fn_type({ cg.world().mem_type() }) });
-                            auto cont = cg.world().continuation(fn_type, {location(), "pe_info"});
+                            auto string_type = cg.world.ptr_type(cg.world.indefinite_array_type(cg.world.type_pu8()));
+                            auto fn_type = cg.world.fn_type({
+                                cg.world.mem_type(), string_type, poly_type,
+                                cg.world.fn_type({ cg.world.mem_type() }) });
+                            auto cont = cg.world.continuation(fn_type, {location(), "pe_info"});
                             cont->set_intrinsic();
                             dst = cont;
                         } else if (name == "pe_known") {
                             auto poly_type = cg.convert(arg(0)->type());
-                            auto fn_type = cg.world().fn_type({
-                                cg.world().mem_type(), poly_type,
-                                cg.world().fn_type({ cg.world().mem_type(), cg.world().type_bool() }) });
-                            auto cont = cg.world().continuation(fn_type, {location(), "pe_known"});
+                            auto fn_type = cg.world.fn_type({
+                                cg.world.mem_type(), poly_type,
+                                cg.world.fn_type({ cg.world.mem_type(), cg.world.type_bool() }) });
+                            auto cont = cg.world.continuation(fn_type, {location(), "pe_known"});
                             cont->set_intrinsic();
                             dst = cont;
                         }
@@ -713,31 +731,32 @@ const Def* MapExpr::remit(CodeGen& cg) const {
         dst = dst ? dst : cg.remit(lhs());
 
         std::vector<const Def*> defs;
-        defs.push_back(nullptr); // reserve for mem but set later - some other args may update the monad
+        defs.push_back(nullptr);    // reserve for mem but set later - some other args may update the monad
         for (const auto& arg : args())
             defs.push_back(cg.remit(arg.get()));
-        defs.front() = cg.get_mem(); // now get the current memory monad
+        defs.front() = cg.cur_mem; // now get the current memory value
 
         auto ret_type = num_args() == fn_type->num_params() ? nullptr : cg.convert(fn_type->return_type());
-        auto ret = cg.call(dst, defs, ret_type, thorin::Debug(location(), dst->name()) + "_cont");
+        const Def* ret;
+        std::tie(cg.cur_bb, ret) = cg.cur_bb->call(dst, defs, ret_type, thorin::Debug(location(), dst->name()) + "_cont");
         if (ret_type)
-            cg.set_mem(cg.cur_bb->param(0));
+            cg.cur_mem = cg.cur_bb->param(0);
 
         return ret;
     } else if (ltype->isa<ArrayType>() || ltype->isa<TupleType>() || ltype->isa<SimdType>()) {
         auto index = cg.remit(arg(0));
-        return cg.extract(cg.remit(lhs()), index, location());
+        return cg.world.extract(cg.remit(lhs()), index, location());
     }
     THORIN_UNREACHABLE;
 }
 
 const Def* FieldExpr::lemit(CodeGen& cg) const {
     auto value = cg.lemit(lhs());
-    return Value::create_agg(value, cg.world().literal_qu32(index(), location()));
+    return cg.world.lea(value, cg.world.literal_qu32(index(), location()), location());
 }
 
 const Def* FieldExpr::remit(CodeGen& cg) const {
-    return cg.extract(cg.remit(lhs()), index(), location());
+    return cg.world.extract(cg.remit(lhs()), index(), location());
 }
 
 const Def* BlockExpr::remit(CodeGen& cg) const {
@@ -747,21 +766,25 @@ const Def* BlockExpr::remit(CodeGen& cg) const {
 }
 
 void IfExpr::emit_jump(CodeGen& cg, Continuation* x) const {
-    JumpTarget t({then_expr()->location().front(), "if_then"});
-    JumpTarget f({else_expr()->location().front(), "if_else"});
+    auto t = cg.world.basicblock({then_expr()->location().front(), "if_then"});
+    auto f = cg.world.basicblock({else_expr()->location().front(), "if_else"});
     cg.emit_branch(cond(), t, f);
-    if (cg.enter(t))
-        cg.emit_jump(then_expr(), x);
-    if (cg.enter(f))
-        cg.emit_jump(else_expr(), x);
-    cg.jump(x, location().back());
+    cg.cur_bb = t;
+    cg.emit_jump(then_expr(), x);
+    cg.cur_bb = f;
+    cg.emit_jump(else_expr(), x);
+    //TODO
+    //cg.cur_bb->jump(x, location().back());
 }
 
 const Def* IfExpr::remit(CodeGen& cg) const {
-    JumpTarget x({location().back(), "next"});
-    return cg.converge(this, x);
+    // TODO
+    /*auto x =*/ cg.world.basicblock({location().back(), "next"});
+    //return cg.converge(this, x);
+    return nullptr;
 }
 
+#if 0
 void MatchExpr::emit_jump(CodeGen& cg, Continuation* x) const {
     auto matcher = cg.remit(expr());
     auto enum_type = expr()->type()->isa<EnumType>();
@@ -788,7 +811,7 @@ void MatchExpr::emit_jump(CodeGen& cg, Continuation* x) const {
                 } else {
                     auto enum_ptrn = arm(i)->ptrn()->as<EnumPtrn>();
                     auto option_decl = enum_ptrn->path()->decl()->as<OptionDecl>();
-                    defs[i] = cg.world().literal_qu32(option_decl->index(), arm(i)->ptrn()->location());
+                    defs[i] = cg.world.literal_qu32(option_decl->index(), arm(i)->ptrn()->location());
                 }
                 targets[i] = JumpTarget({arm(i)->location().front(), "case"});
             }
@@ -796,7 +819,7 @@ void MatchExpr::emit_jump(CodeGen& cg, Continuation* x) const {
         targets.shrink(num_targets);
         defs.shrink(num_targets);
 
-        auto matcher_int = is_integer ? matcher : cg.world().extract(matcher, 0_u32, matcher->debug());
+        auto matcher_int = is_integer ? matcher : cg.world.extract(matcher, 0_u32, matcher->debug());
         cg.match(matcher_int, otherwise, defs, targets, {location().front(), "match"});
 
         for (size_t i = 0; i < num_targets; i++) {
@@ -815,7 +838,7 @@ void MatchExpr::emit_jump(CodeGen& cg, Continuation* x) const {
             arm(i)->ptrn()->emit(cg, matcher);
             // last pattern will always be taken
             auto cond = i == e - 1
-                ? cg.world().literal_bool(true, arm(i)->ptrn()->location())
+                ? cg.world.literal_bool(true, arm(i)->ptrn()->location())
                 : arm(i)->ptrn()->emit_cond(cg, matcher);
 
             cg.branch(cond, cur, next);
@@ -832,19 +855,20 @@ const Def* MatchExpr::remit(CodeGen& cg) const {
     JumpTarget x({location().back(), "next"});
     return cg.converge(this, x);
 }
+#endif
 
 const Def* WhileExpr::remit(CodeGen& cg) const {
-    JumpTarget x({location().back(), "next"});
+    auto x = cg.world.basicblock({location().back(), "next"});
     auto break_continuation = cg.create_continuation(break_decl());
 
     cg.emit_jump(this, x);
     cg.jump_to_continuation(break_continuation, location().back());
-    return cg.world().tuple({}, location());
+    return cg.world.tuple({}, location());
 }
 
 void WhileExpr::emit_jump(CodeGen& cg, Continuation* exit_bb) const {
-    JumpTarget head_bb({cond()->location().front(), "while_head"});
-    JumpTarget body_bb({body()->location().front(), "while_body"});
+    auto head_bb = cg.world.basicblock({cond()->location().front(), "while_head"});
+    auto body_bb = cg.world.basicblock({body()->location().front(), "while_body"});
     auto continue_continuation = cg.create_continuation(continue_decl());
 
     cg.jump(head_bb, cond()->location().back());
@@ -886,7 +910,7 @@ const Def* ForExpr::remit(CodeGen& cg) const {
         Array<const Def*> defs(break_continuation->num_params()-1);
         for (size_t i = 0, e = defs.size(); i != e; ++i)
             defs[i] = break_continuation->param(i+1);
-        return cg.world().tuple(defs, location());
+        return cg.world.tuple(defs, location());
     }
 }
 
@@ -906,13 +930,13 @@ void IdPtrn::emit(CodeGen& cg, const thorin::Def* init) const {
 }
 
 const thorin::Def* IdPtrn::emit_cond(CodeGen& cg, const thorin::Def*) const {
-    return cg.world().literal(true);
+    return cg.world.literal(true);
 }
 
 void EnumPtrn::emit(CodeGen& cg, const thorin::Def* init) const {
     if (num_args() == 0) return;
     auto variant_type = path()->decl()->as<OptionDecl>()->variant_type(cg);
-    auto variant = cg.world().cast(variant_type, cg.world().extract(init, 1), location());
+    auto variant = cg.world.cast(variant_type, cg.world.extract(init, 1), location());
     for (size_t i = 0, e = num_args(); i != e; ++i) {
         cg.emit(arg(i), num_args() == 1 ? variant : cg.extract(variant, i, location()));
     }
@@ -920,14 +944,14 @@ void EnumPtrn::emit(CodeGen& cg, const thorin::Def* init) const {
 
 const thorin::Def* EnumPtrn::emit_cond(CodeGen& cg, const thorin::Def* init) const {
     auto index = path()->decl()->as<OptionDecl>()->index();
-    auto cond = cg.world().cmp_eq(cg.world().extract(init, 0_u32, location()), cg.world().literal_qu32(index, location()));
+    auto cond = cg.world.cmp_eq(cg.world.extract(init, 0_u32, location()), cg.world.literal_qu32(index, location()));
     if (num_args() > 0) {
         auto variant_type = path()->decl()->as<OptionDecl>()->variant_type(cg);
-        auto variant = cg.world().cast(variant_type, cg.world().extract(init, 1, location()), location());
+        auto variant = cg.world.cast(variant_type, cg.world.extract(init, 1, location()), location());
         for (size_t i = 0, e = num_args(); i != e; ++i) {
             if (!arg(i)->is_refutable()) continue;
-            auto arg_cond = arg(i)->emit_cond(cg, num_args() == 1 ? variant : cg.world().extract(variant, i, location()));
-            cond = cg.world().arithop_and(cond, arg_cond, location());
+            auto arg_cond = arg(i)->emit_cond(cg, num_args() == 1 ? variant : cg.world.extract(variant, i, location()));
+            cond = cg.world.arithop_and(cond, arg_cond, location());
         }
     }
     return cond;
@@ -944,20 +968,20 @@ const thorin::Def* TuplePtrn::emit_cond(CodeGen& cg, const thorin::Def* init) co
         if (!elem(i)->is_refutable()) continue;
 
         auto next = elem(i)->emit_cond(cg, cg.extract(init, i, location()));
-        cond = cond ? cg.world().arithop_and(cond, next) : next;
+        cond = cond ? cg.world.arithop_and(cond, next) : next;
     }
-    return cond ? cond : cg.world().literal(true);
+    return cond ? cond : cg.world.literal(true);
 }
 
 const thorin::Def* LiteralPtrn::emit_literal(CodeGen& cg) const {
     auto def = cg.remit(literal());
-    return has_minus() ? cg.world().arithop_minus(def, def->debug()) : def;
+    return has_minus() ? cg.world.arithop_minus(def, def->debug()) : def;
 }
 
 void LiteralPtrn::emit(CodeGen&, const thorin::Def*) const {}
 
 const thorin::Def* LiteralPtrn::emit_cond(CodeGen& cg, const thorin::Def* init) const {
-    return cg.world().cmp_eq(init, emit_literal(cg));
+    return cg.world.cmp_eq(init, emit_literal(cg));
 }
 
 /*
@@ -965,8 +989,7 @@ const thorin::Def* LiteralPtrn::emit_cond(CodeGen& cg, const thorin::Def* init) 
  */
 
 void ExprStmt::emit(CodeGen& cg) const {
-    if (cg.is_reachable())
-        cg.remit(expr());
+    cg.remit(expr());
 }
 
 void ItemStmt::emit(CodeGen& cg) const {
@@ -974,8 +997,7 @@ void ItemStmt::emit(CodeGen& cg) const {
 }
 
 void LetStmt::emit(CodeGen& cg) const {
-    if (cg.is_reachable())
-        cg.emit(ptrn(), init() ? cg.remit(init()) : cg.world().bottom(cg.convert(ptrn()->type()), ptrn()->location()));
+    cg.emit(ptrn(), init() ? cg.remit(init()) : cg.world.bottom(cg.convert(ptrn()->type()), ptrn()->location()));
 }
 
 void AsmStmt::emit(CodeGen& cg) const {
@@ -997,7 +1019,7 @@ void AsmStmt::emit(CodeGen& cg) const {
             flags |= thorin::Assembly::Flags::IsIntelDialect;
     }
 
-    auto assembly = cg.world().assembly(outs, cg.get_mem(), ins, asm_template(),
+    auto assembly = cg.world.assembly(outs, cg.get_mem(), ins, asm_template(),
             output_constraints(), input_constraints(), clobbers(), flags, location());
 
     size_t i = 0;

--- a/src/impala/emit.cpp
+++ b/src/impala/emit.cpp
@@ -332,7 +332,7 @@ void FnDecl::emit(CodeGen& cg) const {
         fn_emit_body(cg, location());
 }
 
-void ExternBlock::emit(CodeGen& cg) const {
+void ExternBlock::emit_head(CodeGen& cg) const {
     for (auto&& fn_decl : fn_decls()) {
         fn_decl->emit_head(cg);
         auto continuation = fn_decl->continuation();
@@ -347,6 +347,15 @@ void ExternBlock::emit(CodeGen& cg) const {
 
 void ModuleDecl::emit(CodeGen&) const {}
 void ImplItem::emit(CodeGen&) const {}
+
+void StaticItem::emit_head(CodeGen& cg) const {
+    auto i = init() ? init()->remit(cg) : cg.world.bottom(cg.convert(type()), location());
+    def_ = is_mut() ? cg.world.global(i, true, debug()) : i;
+}
+
+void StructDecl::emit_head(CodeGen& cg) const {
+    cg.convert(type());
+}
 
 void OptionDecl::emit(CodeGen& cg) const {
     auto enum_type = enum_decl()->type()->as<EnumType>();
@@ -369,16 +378,7 @@ void OptionDecl::emit(CodeGen& cg) const {
     }
 }
 
-void StaticItem::emit_head(CodeGen& cg) const {
-    auto i = init() ? init()->remit(cg) : cg.world.bottom(cg.convert(type()), location());
-    def_ = is_mut() ? cg.world.global(i, true, debug()) : i;
-}
-
-void StructDecl::emit(CodeGen& cg) const {
-    cg.convert(type());
-}
-
-void EnumDecl::emit(CodeGen& cg) const {
+void EnumDecl::emit_head(CodeGen& cg) const {
     for (auto&& option_decl : option_decls())
         option_decl->emit(cg);
     cg.convert(type());

--- a/src/impala/main.cpp
+++ b/src/impala/main.cpp
@@ -6,6 +6,7 @@
 #ifdef LLVM_SUPPORT
 #include "thorin/be/llvm/llvm.h"
 #endif
+#include "thorin/analyses/schedule.h"
 #include "thorin/util/args.h"
 #include "thorin/util/log.h"
 #include "thorin/util/location.h"
@@ -213,6 +214,7 @@ int main(int argc, char** argv) {
             impala::emit(world, module.get());
 
         if (result) {
+            thorin::verify_mem(world);
             if (!nocleanup)
                 world.cleanup();
             if (opt_thorin)

--- a/src/impala/sema/infersema.cpp
+++ b/src/impala/sema/infersema.cpp
@@ -353,13 +353,13 @@ void type_inference(std::unique_ptr<TypeTable>& typetable, const Module* module)
  */
 
 const Var* ASTTypeParam::infer(InferSema& sema) const {
-    for (const auto& bound : bounds())
+    for (auto&& bound : bounds())
         sema.infer(bound.get());
     return sema.var(lambda_depth());
 }
 
 void ASTTypeParamList::infer_ast_type_params(InferSema& sema) const {
-    for (const auto& ast_type_param : ast_type_params())
+    for (auto&& ast_type_param : ast_type_params())
         sema.infer(ast_type_param.get());
 }
 
@@ -518,15 +518,15 @@ void ModuleDecl::infer(InferSema&) const {
 }
 
 void Module::infer(InferSema& sema) const {
-    for (const auto& item : items())
+    for (auto&& item : items())
         sema.infer_head(item.get());
 
-    for (const auto& item : items())
+    for (auto&& item : items())
         sema.infer(item.get());
 }
 
 void ExternBlock::infer(InferSema& sema) const {
-    for (const auto& fn_decl : fn_decls())
+    for (auto&& fn_decl : fn_decls())
         sema.infer(fn_decl.get());
 }
 
@@ -538,7 +538,7 @@ void Typedef::infer(InferSema& sema) const {
         // TODO parametric Typedefs
 #if 0
         auto abs = sema.typedef_abs(sema.type(ast_type())); // TODO might be nullptr
-        for (const auto& lambda : lambdas())
+        for (auto&& lambda : lambdas())
             abs->bind(lambda->lambda());
 #endif
     } else
@@ -783,10 +783,10 @@ const Type* DefiniteArrayExpr::infer(InferSema& sema) const {
     else
         expected_elem_type = sema.type_error();
 
-    for (const auto& arg : args())
+    for (auto&& arg : args())
         sema.rvalue(arg.get());
 
-    for (const auto& arg : args())
+    for (auto&& arg : args())
         expected_elem_type = sema.coerce(expected_elem_type, arg.get());
 
     return sema.definite_array_type(expected_elem_type, num_args());
@@ -801,10 +801,10 @@ const Type* SimdExpr::infer(InferSema& sema) const {
     else
         expected_elem_type = sema.type_error();
 
-    for (const auto& arg : args())
+    for (auto&& arg : args())
         sema.rvalue(arg.get());
 
-    for (const auto& arg : args())
+    for (auto&& arg : args())
         expected_elem_type = sema.coerce(expected_elem_type, arg.get());
 
     return sema.simd_type(expected_elem_type, num_args());
@@ -924,7 +924,7 @@ const Type* MapExpr::infer(InferSema& sema) const {
 
     auto ref = split_ref_type(ltype);
 
-    for (const auto& arg : args())
+    for (auto&& arg : args())
         sema.rvalue(arg.get());
 
     if (ltype->isa<UnknownType>())
@@ -959,12 +959,12 @@ const Type* MapExpr::infer(InferSema& sema) const {
 }
 
 const Type* BlockExpr::infer(InferSema& sema) const {
-    for (const auto& stmt : stmts()) {
+    for (auto&& stmt : stmts()) {
         if (auto item_stmt = stmt->isa<ItemStmt>())
             sema.infer_head(item_stmt->item());
     }
 
-    for (const auto& stmt : stmts())
+    for (auto&& stmt : stmts())
         sema.infer(stmt.get());
 
     return expr() ? sema.rvalue(expr()) : sema.unit()->as<Type>();
@@ -1084,8 +1084,8 @@ void LetStmt::infer(InferSema& sema) const {
 }
 
 void AsmStmt::infer(InferSema& sema) const {
-    for (const auto& output : outputs()) sema.infer(output->expr());
-    for (const auto&  input :  inputs()) sema.rvalue(input->expr());
+    for (auto&& output : outputs()) sema.infer(output->expr());
+    for (auto&&  input :  inputs()) sema.rvalue(input->expr());
 }
 
 //------------------------------------------------------------------------------

--- a/src/impala/sema/namesema.cpp
+++ b/src/impala/sema/namesema.cpp
@@ -32,7 +32,7 @@ public:
     void bind_head(const Item* item) {
         if (item->is_no_decl()) {
             if (const auto& extern_block = item->isa<ExternBlock>()) {
-                for (const auto& fn_decl : extern_block->fn_decls())
+                for (auto&& fn_decl : extern_block->fn_decls())
                     insert(fn_decl.get());
             }
         } else
@@ -112,7 +112,7 @@ void NameSema::pop_scope() {
  */
 
 void ASTTypeParam::bind(NameSema& sema) const {
-    for (const auto& bound : bounds())
+    for (auto&& bound : bounds())
         bound->bind(sema);
 }
 
@@ -132,13 +132,13 @@ void LocalDecl::bind(NameSema& sema) const {
 void ASTTypeParamList::bind_ast_type_params(NameSema& sema) const {
     // we need two runs for types like fn[A:T[B], B:T[A]](A, B)
     // first, insert names and generate De Bruijn index
-    for (const auto& ast_type_param : ast_type_params()) {
+    for (auto&& ast_type_param : ast_type_params()) {
         sema.insert(ast_type_param.get());
         ast_type_param->lambda_depth_ = ++sema.lambda_depth_;
     }
 
     // then, bind bounds
-    for (const auto& ast_type_param : ast_type_params())
+    for (auto&& ast_type_param : ast_type_params())
         ast_type_param->bind(sema);
 }
 
@@ -151,20 +151,20 @@ void SimdASTType::bind(NameSema& sema) const { elem_ast_type()->bind(sema); }
 void Typeof::bind(NameSema& sema) const { expr()->bind(sema); }
 
 void TupleASTType::bind(NameSema& sema) const {
-    for (const auto& ast_type_arg : ast_type_args())
+    for (auto&& ast_type_arg : ast_type_args())
         ast_type_arg->bind(sema);
 }
 
 void ASTTypeApp::bind(NameSema& sema) const {
     path()->bind(sema);
-    for (const auto& ast_type_arg : ast_type_args())
+    for (auto&& ast_type_arg : ast_type_args())
         ast_type_arg->bind(sema);
 }
 
 void FnASTType::bind(NameSema& sema) const {
     sema.push_scope();
     bind_ast_type_params(sema);
-    for (const auto& ast_type_arg : ast_type_args())
+    for (auto&& ast_type_arg : ast_type_args())
         ast_type_arg->bind(sema);
     sema.lambda_depth_ -= num_ast_type_params();
     sema.pop_scope();
@@ -180,18 +180,18 @@ void ModuleDecl::bind(NameSema& ) const {}
 
 void Module::bind(NameSema& sema) const {
     sema.push_scope();
-    for (const auto& item : items()) {
+    for (auto&& item : items()) {
         sema.bind_head(item.get());
         if (item->is_named_decl())
             symbol2item_[item->symbol()] = item.get();
     }
-    for (const auto& item : items())
+    for (auto&& item : items())
         item->bind(sema);
     sema.pop_scope();
 }
 
 void ExternBlock::bind(NameSema& sema) const {
-    for (const auto& fn_decl : fn_decls())
+    for (auto&& fn_decl : fn_decls())
         fn_decl->bind(sema);
 }
 
@@ -206,7 +206,7 @@ void Typedef::bind(NameSema& sema) const {
 void EnumDecl::bind(NameSema& sema) const {
     sema.push_scope();
     bind_ast_type_params(sema);
-    for (const auto& option : option_decls()) {
+    for (auto&& option : option_decls()) {
         option->bind(sema);
         option->enum_decl_ = this;
         option_table_[option->symbol()] = option.get();
@@ -217,7 +217,7 @@ void EnumDecl::bind(NameSema& sema) const {
 
 void OptionDecl::bind(NameSema& sema) const {
     sema.insert(this);
-    for (const auto& arg : args()) arg->bind(sema);
+    for (auto&& arg : args()) arg->bind(sema);
 }
 
 void StaticItem::bind(NameSema& sema) const {
@@ -231,7 +231,7 @@ void Fn::fn_bind(NameSema& sema) const {
     sema.push_scope();
     bind_ast_type_params(sema);
 
-    for (const auto& param : params()) {
+    for (auto&& param : params()) {
         sema.insert(param.get());
         if (param->ast_type())
             param->ast_type()->bind(sema);
@@ -240,7 +240,7 @@ void Fn::fn_bind(NameSema& sema) const {
     if (pe_expr())
         pe_expr()->bind(sema);
 
-    for (const auto& param : params()) {
+    for (auto&& param : params()) {
         if (auto pe_expr = param->pe_expr())
             pe_expr->bind(sema);
     }
@@ -259,7 +259,7 @@ void FnDecl::bind(NameSema& sema) const {
 void StructDecl::bind(NameSema& sema) const {
     sema.push_scope();
     bind_ast_type_params(sema);
-    for (const auto& field_decl : field_decls()) {
+    for (auto&& field_decl : field_decls()) {
         field_decl->bind(sema);
         field_table_[field_decl->symbol()] = field_decl.get();
     }
@@ -275,9 +275,9 @@ void FieldDecl::bind(NameSema& sema) const {
 void TraitDecl::bind(NameSema& sema) const {
     sema.push_scope();
     bind_ast_type_params(sema);
-    for (const auto& t : super_traits())
+    for (auto&& t : super_traits())
         t->bind(sema);
-    for (const auto& method : methods()) {
+    for (auto&& method : methods()) {
         method->bind(sema);
         method_table_[method->symbol()] = method.get();
     }
@@ -291,7 +291,7 @@ void ImplItem::bind(NameSema& sema) const {
     if (trait())
         trait()->bind(sema);
     ast_type()->bind(sema);
-    for (const auto& fn : methods())
+    for (auto&& fn : methods())
         fn->bind(sema);
     sema.lambda_depth_ -= num_ast_type_params();
     sema.pop_scope();
@@ -307,11 +307,11 @@ void EmptyExpr::bind(NameSema&) const {}
 
 void BlockExpr::bind(NameSema& sema) const {
     sema.push_scope();
-    for (const auto& stmt : stmts()) {
+    for (auto&& stmt : stmts()) {
         if (auto item_stmt = stmt->isa<ItemStmt>())
             sema.bind_head(item_stmt->item());
     }
-    for (const auto& stmt : stmts())
+    for (auto&& stmt : stmts())
         stmt->bind(sema);
     expr()->bind(sema);
     sema.pop_scope();
@@ -345,7 +345,7 @@ void ExplicitCastExpr::bind(NameSema& sema) const {
 }
 
 void DefiniteArrayExpr::bind(NameSema& sema) const {
-    for (const auto& arg : args())
+    for (auto&& arg : args())
         arg->bind(sema);
 }
 
@@ -359,30 +359,30 @@ void IndefiniteArrayExpr::bind(NameSema& sema) const {
 }
 
 void TupleExpr::bind(NameSema& sema) const {
-    for (const auto& arg : args())
+    for (auto&& arg : args())
         arg->bind(sema);
 }
 
 void SimdExpr::bind(NameSema& sema) const {
-    for (const auto& arg : args())
+    for (auto&& arg : args())
         arg->bind(sema);
 }
 
 void StructExpr::bind(NameSema& sema) const {
     ast_type_app()->bind(sema);
-    for (const auto& elem : elems())
+    for (auto&& elem : elems())
         elem->expr()->bind(sema);
 }
 
 void TypeAppExpr::bind(NameSema& sema) const {
     lhs()->bind(sema);
-    for (const auto& ast_type_arg : ast_type_args())
+    for (auto&& ast_type_arg : ast_type_args())
         ast_type_arg->bind(sema);
 }
 
 void MapExpr::bind(NameSema& sema) const {
     lhs()->bind(sema);
-    for (const auto& arg : args())
+    for (auto&& arg : args())
         arg->bind(sema);
 }
 
@@ -426,7 +426,7 @@ void ForExpr::bind(NameSema& sema) const {
  */
 
 void TuplePtrn::bind(NameSema& sema) const {
-    for (const auto& elem : elems()) {
+    for (auto&& elem : elems()) {
         elem->bind(sema);
     }
 }
@@ -437,7 +437,7 @@ void IdPtrn::bind(NameSema& sema) const {
 
 void EnumPtrn::bind(NameSema& sema) const {
     path()->bind(sema);
-    for (const auto& arg : args()) {
+    for (auto&& arg : args()) {
         arg->bind(sema);
     }
 }
@@ -458,9 +458,9 @@ void LetStmt::bind(NameSema& sema) const {
     ptrn()->bind(sema);
 }
 void AsmStmt::bind(NameSema& sema) const {
-    for (const auto& output : outputs())
+    for (auto&& output : outputs())
         output->expr()->bind(sema);
-    for (const auto& input : inputs())
+    for (auto&& input : inputs())
         input->expr()->bind(sema);
 }
 

--- a/src/impala/sema/typesema.cpp
+++ b/src/impala/sema/typesema.cpp
@@ -133,14 +133,14 @@ const char* tok2str(const T* expr) { return Token::tok2str(token_tag(expr)); }
  */
 
 const Var* ASTTypeParam::check(TypeSema& sema) const {
-    for (const auto& bound : bounds())
+    for (auto&& bound : bounds())
         sema.check(bound.get());
 
     return var();
 }
 
 void ASTTypeParamList::check_ast_type_params(TypeSema& sema) const {
-    for (const auto& ast_type_param : ast_type_params())
+    for (auto&& ast_type_param : ast_type_params())
         sema.check(ast_type_param.get());
 }
 
@@ -162,7 +162,7 @@ void SimdASTType::check(TypeSema& sema) const {
 }
 
 void TupleASTType::check(TypeSema& sema) const {
-    for (const auto& ast_type_arg : ast_type_args()) {
+    for (auto&& ast_type_arg : ast_type_args()) {
         sema.check(ast_type_arg.get());
         sema.no_indefinite_array(ast_type_arg.get(), ast_type_arg->type(), "element type in a tuple");
     }
@@ -170,7 +170,7 @@ void TupleASTType::check(TypeSema& sema) const {
 
 void FnASTType::check(TypeSema& sema) const {
     check_ast_type_params(sema);
-    for (const auto& ast_type_arg : ast_type_args()) {
+    for (auto&& ast_type_arg : ast_type_args()) {
         sema.check(ast_type_arg.get());
         sema.no_indefinite_array(ast_type_arg.get(), ast_type_arg->type(), "element type in a function type");
     }
@@ -198,7 +198,7 @@ void LocalDecl::check(TypeSema& sema) const {
 const Type* Fn::check_body(TypeSema& sema) const {
     sema.check(body());
 
-    for (const auto& param : params()) {
+    for (auto&& param : params()) {
         if (param->is_mut() && !param->is_written())
             warning(param.get(), "parameter '{}' declared mutable but parameter is never written to", param->symbol());
     }
@@ -231,7 +231,7 @@ void ModuleDecl::check(TypeSema&) const {
 }
 
 void Module::check(TypeSema& sema) const {
-    for (const auto& item : items())
+    for (auto&& item : items())
         sema.check(item.get());
 }
 
@@ -241,7 +241,7 @@ void ExternBlock::check(TypeSema& sema) const {
             error(this, "unknown extern specification");  // TODO: better location
     }
 
-    for (const auto& fn_decl : fn_decls())
+    for (auto&& fn_decl : fn_decls())
         sema.check(fn_decl.get());
 }
 
@@ -252,17 +252,17 @@ void Typedef::check(TypeSema& sema) const {
 
 void EnumDecl::check(TypeSema& sema) const {
     check_ast_type_params(sema);
-    for (const auto& option : option_decls())
+    for (auto&& option : option_decls())
         sema.check(option.get());
 }
 
 void OptionDecl::check(TypeSema& sema) const {
-    for (const auto& arg : args()) sema.check(arg.get());
+    for (auto&& arg : args()) sema.check(arg.get());
 }
 
 void StructDecl::check(TypeSema& sema) const {
     check_ast_type_params(sema);
-    for (const auto& field_decl : field_decls()) {
+    for (auto&& field_decl : field_decls()) {
         sema.check(field_decl.get());
         sema.no_indefinite_array(field_decl.get(), field_decl->type(), "type for a struct field");
     }
@@ -273,7 +273,7 @@ void FieldDecl::check(TypeSema& sema) const { sema.check(ast_type()); }
 void FnDecl::check(TypeSema& sema) const {
     THORIN_PUSH(sema.cur_fn_, this);
     check_ast_type_params(sema);
-    for (const auto& param : params())
+    for (auto&& param : params())
         sema.check(param.get());
 
     if (body() != nullptr)
@@ -289,10 +289,10 @@ void StaticItem::check(TypeSema& sema) const {
 void TraitDecl::check(TypeSema& sema) const {
     check_ast_type_params(sema);
 
-    for (const auto& type_app : super_traits())
+    for (auto&& type_app : super_traits())
         sema.check(type_app.get());
 
-    for (const auto& method : methods())
+    for (auto&& method : methods())
         sema.check(method.get());
 }
 
@@ -302,7 +302,7 @@ void ImplItem::check(TypeSema& sema) const {
 
     if (trait()) {
         if (trait()->isa<ASTTypeApp>()) {
-            for (const auto& type_param : ast_type_params())
+            for (auto&& type_param : ast_type_params())
                 sema.check(type_param.get());
         } else
             error(trait(), "expected trait instance");
@@ -515,7 +515,7 @@ void RValueExpr::check(TypeSema& sema) const {
 }
 
 void TupleExpr::check(TypeSema& sema) const {
-    for (const auto& arg : args()) {
+    for (auto&& arg : args()) {
         sema.check(arg.get());
         sema.no_indefinite_array(arg.get(), arg->type(), "type for an element in a tuple expression");
     }
@@ -534,7 +534,7 @@ void DefiniteArrayExpr::check(TypeSema& sema) const {
     if (auto definite_array_type = type()->isa<DefiniteArrayType>())
         elem_type = definite_array_type->elem_type();
 
-    for (const auto& arg : args()) {
+    for (auto&& arg : args()) {
         sema.check(arg.get());
         if (elem_type)
             sema.expect_type(elem_type, arg.get(), "element of definite array expression");
@@ -546,7 +546,7 @@ void SimdExpr::check(TypeSema& sema) const {
     if (auto simd_type = type()->isa<SimdType>())
         elem_type = simd_type->elem_type();
 
-    for (const auto& arg : args()) {
+    for (auto&& arg : args()) {
         sema.check(arg.get());
         if (elem_type)
             sema.expect_type(elem_type, arg.get(), "element of simd expression");
@@ -558,7 +558,7 @@ void StructExpr::check(TypeSema& sema) const {
     if (auto struct_type = type->isa<StructType>()) {
         auto struct_decl = struct_type->struct_decl();
         thorin::GIDSet<const FieldDecl*> done;
-        for (const auto& elem : elems()) {
+        for (auto&& elem : elems()) {
             sema.check(elem->expr());
 
             if (auto field_decl = elem->field_decl()) {
@@ -571,7 +571,7 @@ void StructExpr::check(TypeSema& sema) const {
         }
 
         if (done.size() != struct_decl->field_table().size()) {
-            for (const auto& p : struct_decl->field_table()) {
+            for (auto&& p : struct_decl->field_table()) {
                 if (!done.contains(p.second))
                     error(this, "missing field '{}'", p.first);
             }
@@ -599,7 +599,7 @@ void TypeAppExpr::check(TypeSema& /*sema*/) const {
 void MapExpr::check(TypeSema& sema) const {
     auto ltype = unpack_ref_type(sema.check(lhs()));
 
-    for (const auto& arg : args())
+    for (auto&& arg : args())
         sema.check(arg.get());
 
     if (ltype->isa<FnType>()) {
@@ -642,12 +642,12 @@ void TypeSema::check_call(const Expr* expr, ArrayRef<const Expr*> args) {
 
 void BlockExpr::check(TypeSema& sema) const {
     THORIN_PUSH(sema.cur_block_, this);
-    for (const auto& stmt : stmts())
+    for (auto&& stmt : stmts())
         sema.check(stmt.get());
 
     sema.check(expr());
 
-    for (const auto& local : locals_) {
+    for (auto&& local : locals_) {
         if (local->is_mut() && !local->is_written())
             warning(local, "variable '{}' declared mutable but variable is never written to", local->symbol());
     }
@@ -727,7 +727,7 @@ void ForExpr::check(TypeSema& sema) const {
 
     if (auto map = forexpr->isa<MapExpr>()) {
         auto ltype = sema.check(map->lhs());
-        for (const auto& arg : map->args())
+        for (auto&& arg : map->args())
             sema.check(arg.get());
         sema.check(fn_expr());
 
@@ -757,7 +757,7 @@ void ForExpr::check(TypeSema& sema) const {
  */
 
 void TuplePtrn::check(TypeSema& sema) const {
-    for (const auto& elem : elems()) {
+    for (auto&& elem : elems()) {
         sema.check(elem.get());
     }
 }
@@ -768,7 +768,7 @@ void IdPtrn::check(TypeSema& sema) const {
 }
 
 void EnumPtrn::check(TypeSema& sema) const {
-    for (const auto& arg : args())
+    for (auto&& arg : args())
         sema.check(arg.get());
 
     auto option_decl = path()->decl()->isa<OptionDecl>();
@@ -836,7 +836,7 @@ void check_correct_asm_type(const Type* t, const Expr *expr) {
 }
 
 void AsmStmt::check(TypeSema& sema) const {
-    for (const auto& output : outputs()) {
+    for (auto&& output : outputs()) {
         auto type = sema.check(output->expr());
 
         if (auto ref = is_lvalue(type))
@@ -848,10 +848,10 @@ void AsmStmt::check(TypeSema& sema) const {
         check_correct_asm_type(type, output->expr());
     }
 
-    for (const auto& input : inputs())
+    for (auto&& input : inputs())
         check_correct_asm_type(sema.check(input->expr()), input->expr());
 
-    for (const auto& option : options()) {
+    for (auto&& option : options()) {
         if (option != "volatile" && option != "alignstack" && option != "intel")
             error(this, "unsupported inline assembly option '{}', only 'volatile', 'alignstack' and 'intel' supported", option);
     }

--- a/test/codegen/float_literal.impala
+++ b/test/codegen/float_literal.impala
@@ -1,0 +1,4 @@
+// codegen
+fn main() -> int {
+    if .5 == 0.5 { 0 } else { 1 }
+}

--- a/test/codegen/match.impala
+++ b/test/codegen/match.impala
@@ -4,13 +4,13 @@ extern "C" {
     fn forty_two() -> int;
 }
 
-fn test1(i: (int, int)) -> int {
-    match i {
-        (2, 3) => 5,
-        (1, x) => x,
-        _ => 0
-    }
-}
+//fn test1(i: (int, int)) -> int {
+    //match i {
+        //(2, 3) => 5,
+        //(1, x) => x,
+        //_ => 0
+    //}
+//}
 
 fn test2(i: int) -> int {
     match i {
@@ -21,8 +21,11 @@ fn test2(i: int) -> int {
 }
 
 fn main() -> int {
+    test2(forty_two())
+    /*
     match (test1((forty_two(), forty_two())), test2(forty_two())) {
         (0, 0) => 0,
         _ => 1,
     }
+    */
 }

--- a/test/codegen/match_color.impala
+++ b/test/codegen/match_color.impala
@@ -4,13 +4,6 @@ extern "C" {
     fn forty_two() -> int;
 }
 
-enum Color {
-    Red(int),
-    Green(int),
-    Blue(int),
-    Nil,
-}
-
 fn main() -> int {
     let x = Color::Red(forty_two());
 
@@ -22,4 +15,11 @@ fn main() -> int {
         Color::Nil      => 1,
         _               => 2,
     }
+}
+
+enum Color {
+    Red(int),
+    Green(int),
+    Blue(int),
+    Nil,
 }

--- a/test/codegen/mutable_load.impala
+++ b/test/codegen/mutable_load.impala
@@ -1,0 +1,15 @@
+// codegen
+struct S {
+    a: int,
+    b: int
+}
+extern "thorin" { fn sizeof[T]() -> int; }
+extern "C" { fn impala_memmove(&mut [u8], &[u8], i32) -> (); }
+
+fn main() -> int {
+    let mut s = S { a: 0, b: 1 };
+    let mut a = s.a;
+    let b = s.b;
+    impala_memmove(&mut a as &mut[u8], &s.a as &[u8], sizeof[int]());
+    if ?b { 0 } else { 1 }
+}

--- a/test/codegen/struct.impala
+++ b/test/codegen/struct.impala
@@ -1,13 +1,13 @@
 // codegen
 
-struct Vec3 {
-    x: int,
-    y: int,
-    z: int,
-}
-
 fn main() -> int {
     let mut v = Vec3{x: 1, y: 2, z: 3};
     v.z += 36;
     if v.x + v.y + v.z == 42 { 0 } else { 1 }
+}
+
+struct Vec3 {
+    x: int,
+    y: int,
+    z: int,
 }

--- a/test/run.py
+++ b/test/run.py
@@ -57,7 +57,7 @@ class test:
 
 def parse_args():
     parser = argparse.ArgumentParser(formatter_class = argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('path', nargs='*',          help='path to test  or test directory',      default='./', type=str)
+    parser.add_argument('path', nargs='+',          help='path to test  or test directory',      default='./', type=str)
     parser.add_argument('-c',  '--clang',           help='path to clang binary',                 default=None, type=str)
     parser.add_argument('-i',  '--impala',          help='path to impala binary',                default=None, type=str)
     parser.add_argument('-it', '--impala-timeout',  help='timeout for compiling impala ',        default=5,    type=int)

--- a/test/run.py
+++ b/test/run.py
@@ -209,7 +209,7 @@ def run_tests():
                 tmp_log_file = open(tmp_log, 'w')
 
                 # invoke impala
-                cmd_impala = [args.impala,orig_impala, '-emit-llvm', '-O2']
+                cmd_impala = [args.impala,orig_impala, '-emit-llvm', '-O2', '-log-level', 'warn']
 
                 try:
                     p = subprocess.run(cmd_impala, stderr=tmp_log_file, stdout=tmp_log_file, timeout=args.impala_timeout)


### PR DESCRIPTION
Removes SSA construction stuff and just relies on the ```resolve_loads```.

All test cases pass. 
@madmann91 However, I need some help with the code generation for the ```MatchExpr```. This is currently not working. Speaking of this, we probably want to add some test cases for this.

Depends on anydsl/thorin#97.